### PR TITLE
[EXE-1563] Set up publish to Artifactory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,9 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3.3"
-val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
+val sparkVersion = "3.3.2"
+val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
+val defaultScalaVersion = "2.12.15"
 
 /*
  * Don't change the variable name "sparkConnectorVersion" because
@@ -26,7 +27,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse("3.3.0")
  * Tests/jenkins/BumpUpSparkConnectorVersion/run.sh
  * in snowflake repository.
  */
-val sparkConnectorVersion = "2.11.3"
+val sparkConnectorVersion = "2.11.3-aiq0"
 
 lazy val ItTest = config("it") extend Test
 
@@ -38,13 +39,14 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
   .settings(inConfig(ItTest)(Defaults.testSettings))
   .settings(Defaults.coreDefaultSettings)
   .settings(Defaults.itSettings)
+  .enablePlugins(PublishToArtifactory)
   .settings(
     name := "spark-snowflake",
     organization := "net.snowflake",
     version := s"${sparkConnectorVersion}-spark_3.3",
-    scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = "2.12.11"),
+    scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = defaultScalaVersion),
     // Spark 3.2/3.3 supports scala 2.12 and 2.13
-    crossScalaVersions := Seq("2.12.11", "2.13.9"),
+    crossScalaVersions := Seq("2.12.11", defaultScalaVersion),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
@@ -126,13 +128,4 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
             <url>https://github.com/Mingli-Rui</url>
           </developer>
         </developers>,
-
-    publishTo := Some(
-      if (isSnapshot.value) {
-        Opts.resolver.sonatypeSnapshots
-      } else {
-        Opts.resolver.sonatypeStaging
-      }
-    )
-
   )

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val root = project.withId("spark-snowflake").in(file("."))
     version := s"${sparkConnectorVersion}-spark_3.3",
     scalaVersion := sys.props.getOrElse("SPARK_SCALA_VERSION", default = defaultScalaVersion),
     // Spark 3.2/3.3 supports scala 2.12 and 2.13
-    crossScalaVersions := Seq("2.12.11", defaultScalaVersion),
+    crossScalaVersions := Seq(defaultScalaVersion),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),

--- a/project/ArtifactoryCredentials.scala
+++ b/project/ArtifactoryCredentials.scala
@@ -1,0 +1,18 @@
+import sbt.Keys.credentials
+import sbt.{AutoPlugin, Credentials, Def, PluginTrigger}
+
+// Mirrors aiq - ArtifactoryCredentials
+object ArtifactoryCredentials extends AutoPlugin {
+
+  lazy val credentialSettings: Seq[Def.Setting[_]] = Seq(
+    // Attempts to use environment variables if available to configure Artifactory
+    credentials ++= sys.env.get("ARTIFACTORY_ACCESS_TOKEN").toList.map { token =>
+      Credentials("Artifactory Realm", "actioniq.jfrog.io", sys.env("ARTIFACTORY_USER"), token)
+    }
+  )
+
+  // Applying this to all builds automatically for now. trigger = allRequirements with no requirements
+  override def trigger: PluginTrigger = allRequirements
+
+  override def projectSettings: Seq[Def.Setting[_]] = credentialSettings
+}

--- a/project/PublishToArtifactory.scala
+++ b/project/PublishToArtifactory.scala
@@ -1,0 +1,24 @@
+import sbt.Keys.{isSnapshot, packageDoc, packageSrc, publishArtifact, publishConfiguration, publishLocalConfiguration, publishM2Configuration, publishMavenStyle, publishTo}
+import sbt.{Def, _}
+
+// Mirrors aiq - PublishToArtifactory
+object PublishToArtifactory extends AutoPlugin {
+
+  lazy val baseSettings: Seq[Def.Setting[_]] = Seq(
+    publishTo := Some("Artifactory Realm".at("https://actioniq.jfrog.io/artifactory/aiq-sbt-local")),
+    publishMavenStyle := true,
+    publishConfiguration := publishConfiguration.value.withOverwrite(isSnapshot.value),
+    publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(isSnapshot.value),
+    publishM2Configuration := publishM2Configuration.value.withOverwrite(isSnapshot.value),
+    Compile / packageSrc / publishArtifact := false,
+    Compile / packageDoc / publishArtifact := false,
+  )
+
+  override def requires: Plugins = ArtifactoryCredentials
+
+  override def trigger: PluginTrigger = noTrigger
+
+  // a group of settings that are automatically added to projects.
+  override val projectSettings: Seq[Def.Setting[_]] = baseSettings
+
+}


### PR DESCRIPTION
Adding sbt plugins and settings to publish to aiq Artifactory

`sbt publish`
```
[info] 	published spark-snowflake_2.12 to https://actioniq.jfrog.io/artifactory/aiq-sbt-local/net/snowflake/spark-snowflake_2.12/2.11.3-aiq0-spark_3.3/spark-snowflake_2.12-2.11.3-aiq0-spark_3.3.pom
[info] 	published spark-snowflake_2.12 to https://actioniq.jfrog.io/artifactory/aiq-sbt-local/net/snowflake/spark-snowflake_2.12/2.11.3-aiq0-spark_3.3/spark-snowflake_2.12-2.11.3-aiq0-spark_3.3.jar
```