### PR TITLE
[EXE-1630] Pushdown aiq_day_start

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+
+// Custom version of fm-sbt-s3-resolver published to our Artifactory for DEVX-275
+// See repo here: https://github.com/ActionIQ/sbt-s3-resolver
+addSbtPlugin("co.actioniq" % "sbt-s3-resolver" % "1.0.1")

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -194,8 +194,7 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
           }
         }
 
-      // On Spark 2.4, Union() has 1 parameter only.
-      case Union(children) =>
+      case Union(children, _, executeAsFullOuter) if !executeAsFullOuter =>
         Some(UnionQuery(children, alias.next))
 
       case Expand(projections, output, child) =>

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/package.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/package.scala
@@ -149,6 +149,13 @@ package object querygeneration {
     }
   }
 
+  private[querygeneration] def functionStatement(
+    name: String,
+    args: Seq[SnowflakeSQLStatement],
+  ): SnowflakeSQLStatement = {
+    ConstantString(name) + blockStatement(mkStatement(args, ","))
+  }
+
   final def mkStatement(
     seq: Seq[SnowflakeSQLStatement],
     delimiter: SnowflakeSQLStatement


### PR DESCRIPTION
[EXE-1630]

Add pushdown support for the new function from https://github.com/ActionIQ/flame/pull/488. Note this PR should go in after that PR, because we have to build/publish Flame with the new function, then use that version here.

Also had to add some generic stuff for pulling from s3/artifactory (mostly copied from the stuff we did in the Spark3 version of this code at https://github.com/ActionIQ/spark-snowflake/pulls?q=is%3Apr+is%3Aclosed

### Test Notes
Added a unit tests that verifies the result and the Snowflake query. It runs against a real server, export these params to configure it:

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

Then run integration tests, which will hit the live server and output the queryId, so you can check the query on the server like https://app.snowflake.com/axipjne/actioniqp/#/compute/history/queries/01aeb429-0408-303e-0000-8ac500b49312/detail

```
sbt test
sbt it:test // takes a long time, if flaky, just run the below 2

sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01
sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02
```

### Deploy
`sbt publish` should put it in artifactory

[EXE-1630]: https://actioniq.atlassian.net/browse/EXE-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ