### PR TITLE
[EXE-1914] Pushdown for Spark instr()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "2-4-7-aiq63"
+val sparkVersion = "2-4-7-aiq64"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
-// publish version of this connector
-val sparkConnectorVersion = "2.9.3-aiq7"
+// increment this version when making a new release
+val sparkConnectorVersion = "2.9.3-aiq8"
 
 // keep in sync with spark version
 val fasterXmlVer = "2.9.10"

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -259,6 +259,53 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
   }
 
+  test("AIQ test pushdown instr") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(s string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"('hello world')")
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr(
+      "instr(s, 'l')",
+      "instr(s, 'hell')",
+      "instr(s, ' w')",
+      "instr(s, ' ')",
+      "instr(s, ' d ')",
+      "instr(s, 'NOPE')",
+      "instr(s, NULL)",
+      "instr(NULL, 'foo')",
+    )
+    val expectedResult = Seq(Row(
+      3,
+      1,
+      6,
+      6,
+      0,
+      0,
+      null,
+      null,
+    ))
+    checkAnswer(resultDF, expectedResult)
+
+    val pushDf = tmpDF.selectExpr("instr(s, 'hell')")
+    testPushdown(
+      s"""
+         |SELECT ( CHARINDEX ( 'hell' , "SUBQUERY_0"."S" )
+         |  ) AS "SUBQUERY_1_COL_0" FROM (
+         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  ) AS "SUBQUERY_0"
+         |""".stripMargin,
+      pushDf,
+      Seq(Row(1))
+    )
+  }
+
   test("test pushdown functions date_add/date_sub") {
     jdbcUpdate(s"create or replace table $test_table_date " +
       s"(d1 date)")

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -14,6 +14,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   StringTranslate,
   StringTrim,
   StringTrimLeft,
+  StringInstr,
   StringTrimRight,
   Substring,
   Upper
@@ -44,6 +45,11 @@ private[querygeneration] object StringStatement {
           _: StringTrimRight | _: Substring | _: Upper | _: Length =>
         ConstantString(expr.prettyName.toUpperCase) +
           blockStatement(convertStatements(fields, expr.children: _*))
+
+      // Spark INSTR and Snowflake CHARINDEX are both 1-based, but their args are swapped
+      case StringInstr(left, right) =>
+        ConstantString("CHARINDEX") +
+          blockStatement(convertStatements(fields, Seq(right, left): _*))
 
       case Concat(children) =>
         val rightSide =


### PR DESCRIPTION
Add pushdown support for [Spark instr](https://docs.databricks.com/en/sql/language-manual/functions/instr.html), its the same as [Snowflake charindex](https://docs.snowflake.com/en/sql-reference/functions/charindex) but the args are swapped.

### Test Notes
Added a unit test for correctness and pushdown

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI

sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01
sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02
```

Also ran the same thing against Spark shell to show it returns same results 
```
scala> Seq(("hello world")).toDF("s").selectExpr(
      "instr(s, 'l')",
      "instr(s, 'hell')",
      "instr(s, ' w')",
      "instr(s, ' ')",
      "instr(s, ' d ')",
      "instr(s, 'NOPE')",
      "instr(s, NULL)",
      "instr(NULL, 'foo')",
    ).collect()
res1: Array[org.apache.spark.sql.Row] = Array([3,1,6,6,0,0,null,null])
```

### Deploy
`sbt publish`

[EXE-1630]: https://actioniq.atlassian.net/browse/EXE-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ