### PR TITLE
[EXE-1905][EXE-1909] Add `date_to_string` & `string_to_date` functions Pushdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "2-4-7-aiq64"
+val sparkVersion = "2-4-7-aiq65"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.9.3-aiq8"
+val sparkConnectorVersion = "2.9.3-aiq9"
 
 // keep in sync with spark version
 val fasterXmlVer = "2.9.10"

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -424,7 +424,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:ss", "America/New_York"),
       aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:mm:ss", "America/New_York"),
     )
-    val pushExpectedResult = Seq(Row(expectedResult.map(_.getString(0)).mkString(",")))
+    val pushExpectedResult = Seq(Row(expectedResult.map(_.getString(0)): _*))
     checkAnswer(pushResultDF, pushExpectedResult)
 
     val finalPushResultDF = pushDf.select(

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -414,9 +414,22 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       .load()
 
     val pushResultDF = pushDf.select(
+      aiq_date_to_string(col("ts"), "MM", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm:mm:ss a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:mm:ss", "America/New_York"),
+    )
+    val pushExpectedResult = Seq(Row(expectedResult.map(_.getString(0)).mkString(",")))
+    checkAnswer(pushResultDF, pushExpectedResult)
+
+    val finalPushResultDF = pushDf.select(
       aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York")
     )
-
     testPushdown(
       s"""
          |SELECT (
@@ -429,7 +442,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |) AS "SUBQUERY_1_COL_0"
          |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
-      pushResultDF,
+      finalPushResultDF,
       Seq(Row("2019-09-01 14:50:52"))
     )
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -23,6 +23,7 @@ private[querygeneration] object DateStatement {
       .replaceAll("hh", "HH12") // Snowflake Two digits for hour (01 through 12)
       .replaceAll("a", "AM")    // Snowflake Ante meridiem (am) / post meridiem (pm)
       .replaceAll("mm", "mi")   // Snowflake Two digits for minute (00 through 59)
+      .replaceAll("ss", "SS")   // Snowflake Two digits for second (00 through 59)
   }
 
   def unapply(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -119,7 +119,8 @@ private[querygeneration] object DateStatement {
         epoch_millisecond,
         CONVERT_TIMEZONE(
           'America/New_York',
-          TO_TIMESTAMP(
+          'UTC',
+          TO_TIMESTAMP_NTZ(
             '2019-09-01 14:50:52',
             'yyyy-MM-dd HH:mm:ss'
           )

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -113,7 +113,7 @@ private[querygeneration] object DateStatement {
 
       /*
       --- spark.sql(
-      ---   "select aiq_string_to_date('2019-09-01 14:50:52', 'yyyy-MM-dd hh:mm:ss', 'America/New_York')"
+      ---   "select aiq_string_to_date('2019-09-01 14:50:52', 'yyyy-MM-dd HH:mm:ss', 'America/New_York')"
       --- ).as[Long].collect.head == 1567363852000L
       select DATE_PART(
         epoch_millisecond,
@@ -121,7 +121,7 @@ private[querygeneration] object DateStatement {
           'America/New_York',
           TO_TIMESTAMP(
             '2019-09-01 14:50:52',
-            'yyyy-MM-dd hh:mm:ss'
+            'yyyy-MM-dd HH:mm:ss'
           )
         )
       )
@@ -136,12 +136,13 @@ private[querygeneration] object DateStatement {
             functionStatement(
               "CONVERT_TIMEZONE",
               Seq(
-                convertStatement(timezoneStr, fields),
+                convertStatement(timezoneStr, fields), // time zone of the input timestamp
+                ConstantString("'UTC'").toStatement, // time zone to be converted
                 functionStatement(
-                  "TO_TIMESTAMP",
+                  "TO_TIMESTAMP_NTZ", // timestamp with no time zone
                   Seq(
                     convertStatement(dateStr, fields),
-                    ConstantString(format).toStatement,
+                    ConstantString(s"'$format'").toStatement,
                   )
                 ),
               ),
@@ -181,7 +182,7 @@ private[querygeneration] object DateStatement {
                 )
               )
             ),
-            ConstantString(format).toStatement,
+            ConstantString(s"'$format'").toStatement,
           )
         )
 


### PR DESCRIPTION
Add pushdown support (when `date format` is foldable) for `date_to_string` and `string_to_date`

# Test Notes

Added a unit tests that verifies the result and the Snowflake query. It runs against a real server, export these params to configure it:

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI

sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01 >> test_enhancement_01.log
sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02 >> test_enhancement_02.log

...
[info] - test pushdown boolean functions: NOT/Contains/EndsWith/StartsWith
[info] - test pushdown number functions: PI() and Round()/Random !!! IGNORED !!!
[info] - AIQ test pushdown day_start
[info] - AIQ test pushdown instr
[info] - AIQ test pushdown string_to_date
[info] - AIQ test pushdown date_to_string
[info] - test pushdown functions date_add/date_sub
[info] - test pushdown functions date_add/date_sub on Feb last day in leap and non-leap year
...
```

# Deploy

`sbt publish`
