### PR TITLE
[SPARK3][EXE-1905][EXE-1909] Add date_to_string & string_to_date functions pushdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq26"
+val sparkVersion = "3-3-2-aiq29"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq4"
+val sparkConnectorVersion = "2.11.3-aiq5"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -337,6 +337,177 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
   }
 
+  test("AIQ test pushdown string_to_date") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(dt string, fmt string, tz string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"""
+         |('2019-09-01 14:50', 'yyyy-MM-dd HH:mm', 'America/New_York'),
+         |('2019-09-01 02:50 PM', 'yyyy-MM-dd hh:mm a', 'America/New_York'),
+         |('2019-09-01 PM 02:50', 'yyyy-MM-dd a hh:mm', 'America/New_York')
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr("aiq_string_to_date(dt, fmt, tz)")
+    val expectedResult = Seq(
+      Row(1567363800000L),
+      Row(1567363800000L),
+      Row(1567363800000L),
+    )
+    checkAnswer(resultDF, expectedResult)
+
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      "(dt string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      "('2019-09-01 14:50:52')")
+
+    val pushDf = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val pushResultDF = pushDf.selectExpr(
+      "aiq_string_to_date(dt, 'yyyy-MM-dd HH:mm:ss', 'America/New_York')"
+    )
+
+    testPushdown(
+      s"""
+         |SELECT (
+         |  DATE_PART (
+         |    epoch_millisecond ,
+         |    CONVERT_TIMEZONE (
+         |      'America/New_York' ,
+         |      'UTC' ,
+         |      TO_TIMESTAMP_NTZ ( "SUBQUERY_0"."DT" , 'yyyy-MM-dd HH24:mi:SS' )
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_0"
+         |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      pushResultDF,
+      Seq(Row(1567363852000L))
+    )
+  }
+
+  test("AIQ test pushdown date_to_string") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(ts bigint, fmt string, tz string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"""
+         |(1567363852000, 'MM', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd HH:mm', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm a', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd a hh:mm', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd a hh:mm:mm:ss a', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd HH:mm:ss', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr("aiq_date_to_string(ts, fmt, tz)")
+    val expectedResult = Seq(
+      Row("09"),
+      Row("2019-09-01"),
+      Row("2019-09-01 14:50"),
+      Row("2019-09-01 02:50 PM"),
+      Row("2019-09-01 PM 02:50"),
+      Row("2019-09-01 PM 02:50:50:52 PM"),
+      Row("2019-09-01 14:50:52"),
+      Row("2019-09-01 02:50:52"),
+      Row("2019-09-01 02:50:50:52"),
+    )
+    checkAnswer(resultDF, expectedResult)
+
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      "(ts bigint)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      "(1567363852000)")
+
+    val pushDf = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val pushResultDF = pushDf.select(
+      aiq_date_to_string(col("ts"), "MM", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm:mm:ss a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd M HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMa HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMMMa HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd E HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEEEEEE HH:mm:ss", "America/New_York"),
+    )
+    val extraFormattingExpectedResults = Seq(
+      "2019-09-01 09 14:50:52",
+      "2019-09-01 09 14:50:52",
+      "2019-09-01 PM09PM 14:50:52",
+      "2019-09-01 Sep 14:50:52",
+      "2019-09-01 PMSepPM 14:50:52",
+      "2019-09-01 September 14:50:52",
+      "2019-09-01 SeptemberM 14:50:52",
+      "2019-09-01 September 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sunday 14:50:52",
+      "2019-09-01 Sunday 14:50:52",
+    )
+    val pushExpectedResult = Seq(
+      Row(expectedResult.map(_.getString(0)) ++ extraFormattingExpectedResults: _*)
+    )
+    checkAnswer(pushResultDF, pushExpectedResult)
+
+    val finalPushResultDF = pushDf.select(
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York")
+    )
+    testPushdown(
+      s"""
+         |SELECT (
+         |  TO_CHAR (
+         |    TO_TIMESTAMP (
+         |      CONVERT_TIMEZONE ( 'America/New_York' , CAST ( "SUBQUERY_0"."TS" AS NUMBER ) ::varchar )
+         |    ) ,
+         |    'yyyy-MM-dd HH24:mi:SS'
+         |  )
+         |) AS "SUBQUERY_1_COL_0"
+         |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      finalPushResultDF,
+      Seq(Row("2019-09-01 14:50:52"))
+    )
+  }
+
   test("test pushdown functions date_add/date_sub") {
     jdbcUpdate(s"create or replace table $test_table_date " +
       s"(d1 date)")

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -1,7 +1,7 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
 import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{AddMonths, AiqDayStart, Attribute, DateAdd, DateSub, Expression, Month, Quarter, TruncDate, TruncTimestamp, Year}
+import org.apache.spark.sql.catalyst.expressions.{AddMonths, AiqDateToString, AiqDayStart, AiqStringToDate, Attribute, DateAdd, DateSub, Expression, Month, Quarter, TruncDate, TruncTimestamp, Year}
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object DateStatement {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -10,6 +10,33 @@ private[querygeneration] object DateStatement {
   // And the syntax is some different.
   val SNOWFLAKE_DATEADD = "DATEADD"
 
+  /**
+   * Function to convert a regular date format to a Snowflake date format
+   *   - Note: This solution has the limitation that `mm` indicates only minutes.
+   *     This is true for regular date formats but in Snowflake `MM` (month)
+   *     and `mm` are the same. Since our system supports the former this is an
+   *     acceptable limitation (for now).
+   */
+  private def sparkDateFmtToSnowflakeDateFmt(format: String): String = {
+    format
+      // Snowflake Two digits for hour (00 through 23)
+      .replaceAll("HH", "HH24")
+      // Snowflake Two digits for hour (01 through 12)
+      .replaceAll("hh", "HH12")
+      // Snowflake Two digits for minute (00 through 59)
+      .replaceAll("mm", "mi")
+      // Snowflake Two digits for second (00 through 59)
+      .replaceAll("ss", "SS")
+      // Snowflake Two-digit month => M -> MM
+      .replaceAll("(?<=[^M])M(?=[^M])", "MM")
+      // Snowflake Abbreviated month name => MMM -> MON
+      .replaceAll("(?<=[^M])M{3}(?=[^M])", "MON")
+      // Snowflake Abbreviated day of week
+      .replaceAll("E{1,3}", "DY")
+      // Snowflake Ante meridiem (am) / post meridiem (pm)
+      .replaceAll("a", "AM")
+  }
+
   def unapply(
     expAttr: (Expression, Seq[Attribute])
   ): Option[SnowflakeSQLStatement] = {
@@ -93,6 +120,82 @@ private[querygeneration] object DateStatement {
               ),
             ),
           ),
+        )
+
+      /*
+      --- spark.sql(
+      ---   "select aiq_string_to_date('2019-09-01 14:50:52', 'yyyy-MM-dd HH:mm:ss', 'America/New_York')"
+      --- ).as[Long].collect.head == 1567363852000L
+      select DATE_PART(
+        epoch_millisecond,
+        CONVERT_TIMEZONE(
+          'America/New_York',
+          'UTC',
+          TO_TIMESTAMP_NTZ(
+            '2019-09-01 14:50:52',
+            'yyyy-MM-dd HH:mm:ss'
+          )
+        )
+      )
+      -- 1567363852000
+      */
+      case AiqStringToDate(dateStr, formatStr, timezoneStr) if formatStr.foldable =>
+        val format = sparkDateFmtToSnowflakeDateFmt(formatStr.eval().toString)
+        functionStatement(
+          "DATE_PART",
+          Seq(
+            ConstantString("epoch_millisecond").toStatement,
+            functionStatement(
+              "CONVERT_TIMEZONE",
+              Seq(
+                convertStatement(timezoneStr, fields), // time zone of the input timestamp
+                ConstantString("'UTC'").toStatement, // time zone to be converted
+                functionStatement(
+                  "TO_TIMESTAMP_NTZ", // timestamp with no time zone
+                  Seq(
+                    convertStatement(dateStr, fields),
+                    ConstantString(s"'$format'").toStatement,
+                  )
+                ),
+              ),
+            ),
+          )
+        )
+
+      /*
+      --- spark.sql(
+      ---   """select aiq_date_to_string(1567363852000, "yyyy-MM-dd HH:mm", 'America/New_York')"""
+      --- ).as[String].collect.head == "2019-09-01 14:50"
+      select TO_CHAR(
+        TO_TIMESTAMP(
+          CONVERT_TIMEZONE(
+            'America/New_York',
+            1567363852000::varchar
+          )
+        ),
+        'yyyy-mm-dd HH:mm'
+      )
+      -- 2019-09-01 14:50
+      */
+      case AiqDateToString(timestampLong, formatStr, timezoneStr) if formatStr.foldable =>
+        val format = sparkDateFmtToSnowflakeDateFmt(formatStr.eval().toString)
+        functionStatement(
+          "TO_CHAR",
+          Seq(
+            functionStatement(
+              "TO_TIMESTAMP",
+              Seq(
+                functionStatement(
+                  "CONVERT_TIMEZONE",
+                  Seq(
+                    convertStatement(timezoneStr, fields),
+                    convertStatement(timestampLong, fields) + ConstantString("::varchar"),
+                  ),
+                )
+              )
+            ),
+            ConstantString(s"'$format'").toStatement,
+          )
         )
 
       case _ => null


### PR DESCRIPTION
Spark3 for https://github.com/ActionIQ/spark-snowflake/pull/11 and https://github.com/ActionIQ/spark-snowflake/pull/12

### Test Notes
```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI

sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01
sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02
```

### Deploy Notes
`sbt publish`