### PR TITLE
[EXE-2055][SPARK3] Pushdown for approx_count_distinct

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq41"
+val sparkVersion = "3-3-2-aiq40"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq29"
+val sparkVersion = "3-3-2-aiq41"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq5"
+val sparkConnectorVersion = "2.11.3-aiq6"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -21,7 +21,6 @@ import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import net.snowflake.spark.snowflake.pushdowns.SnowflakeStrategy
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
-import org.slf4j.LoggerFactory
 
 import scala.util.matching.Regex
 
@@ -47,6 +46,15 @@ trait IntegrationSuiteBase
         s"fs.azure.sas.$container.$account.$endpoint"
       case _ => throw new IllegalArgumentException(s"invalid wasb url: $input")
     }
+  }
+
+  /**
+   * Only verifies the SQL generation, not the result
+   */
+  def testPushdownSql(query: String, result: DataFrame): Unit = {
+    val _ = result.collect()
+    val potentialQuery = query.trim.replaceAll("\\s+", "").toLowerCase
+    assert(potentialQuery == Utils.getLastSelect.replaceAll("\\s+", "").toLowerCase)
   }
 
   /**

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -304,10 +304,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       .option("dbtable", test_table_date)
       .load()
 
-    // select(hll("subquery_1"."subquery_1_col_0"))as"subquery_2_col_0"
-    // from(select("subquery_0"."s")as"subquery_1_col_0"from
-    // (select*from(test_table_date_9196197740175164745)as"sf_connector_query_alias")as"subquery_0")
-    // as"subquery_1"limit1
     val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
     testPushdown(
       s"""
@@ -315,8 +311,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |FROM (
          |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
          |  FROM (
-         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" AS "SUBQUERY_0"
-         |  ) AS "SUBQUERY_0"
+         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |  ) AS "SUBQUERY_1" LIMIT 1
          |""".stripMargin,
       pushDf,
       Seq(Row(2))
@@ -329,8 +325,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |FROM (
          |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
          |  FROM (
-         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" AS "SUBQUERY_0"
-         |  ) AS "SUBQUERY_0"
+         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |  ) AS "SUBQUERY_1" LIMIT 1
          |""".stripMargin,
       pushDf2,
       Seq(Row(3))

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -304,12 +304,18 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       .option("dbtable", test_table_date)
       .load()
 
+    // select(hll("subquery_1"."subquery_1_col_0"))as"subquery_2_col_0"
+    // from(select("subquery_0"."s")as"subquery_1_col_0"from
+    // (select*from(test_table_date_9196197740175164745)as"sf_connector_query_alias")as"subquery_0")
+    // as"subquery_1"limit1
     val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
     testPushdown(
       s"""
-         |SELECT ( HLL ( "SUBQUERY_0"."S" )
-         |  ) AS "SUBQUERY_1_COL_0" FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+         |FROM (
+         |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
+         |  FROM (
+         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" AS "SUBQUERY_0"
          |  ) AS "SUBQUERY_0"
          |""".stripMargin,
       pushDf,
@@ -319,9 +325,11 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val pushDf2 = tmpDF.selectExpr("approx_count_distinct(i)")
     testPushdown(
       s"""
-         |SELECT ( HLL ( "SUBQUERY_0"."I" )
-         |  ) AS "SUBQUERY_1_COL_0" FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+         |FROM (
+         |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
+         |  FROM (
+         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" AS "SUBQUERY_0"
          |  ) AS "SUBQUERY_0"
          |""".stripMargin,
       pushDf2,

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -290,49 +290,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
   }
 
-  test("AIQ test approx_count_dist") {
-    jdbcUpdate(s"create or replace table $test_table_date (s string, i int)")
-    jdbcUpdate(s"insert into $test_table_date values ('hello world', 0)")
-    jdbcUpdate(s"insert into $test_table_date values ('hello world', 0)")
-    jdbcUpdate(s"insert into $test_table_date values ('hello blah', 1)")
-    jdbcUpdate(s"insert into $test_table_date values ('hello blah', 1)")
-    jdbcUpdate(s"insert into $test_table_date values ('hello blah', 2)")
-
-    val tmpDF = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
-    testPushdown(
-      s"""
-         |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
-         |FROM (
-         |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
-         |  FROM (
-         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-         |  ) AS "SUBQUERY_1" LIMIT 1
-         |""".stripMargin,
-      pushDf,
-      Seq(Row(2))
-    )
-
-    val pushDf2 = tmpDF.selectExpr("approx_count_distinct(i)")
-    testPushdown(
-      s"""
-         |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
-         |FROM (
-         |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
-         |  FROM (
-         |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-         |  ) AS "SUBQUERY_1" LIMIT 1
-         |""".stripMargin,
-      pushDf2,
-      Seq(Row(3))
-    )
-  }
-
   test("AIQ test pushdown instr") {
     jdbcUpdate(s"create or replace table $test_table_date " +
       s"(s string)")
@@ -953,6 +910,58 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     // ByPass query text check for COPY UNLOAD
     testPushdownMultiplefQueries(expectedQueries2, df2, expectedResult2,
       bypass = params.useCopyUnload)
+  }
+
+  test("AIQ test approx_count_dist") {
+    jdbcUpdate(s"create or replace table $test_table_date (s string, i int)")
+    (0 until 100).foreach { i =>
+      if (i % 5 == 0) {
+        jdbcUpdate(s"insert into $test_table_date values ('hello $i', $i)")
+      }
+      jdbcUpdate(s"insert into $test_table_date values ('hello $i', ${i.max(30)})")
+    }
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    {
+      val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
+      testPushdownSql(
+        s"""
+           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+           |FROM (
+           |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
+           |  FROM (
+           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |  ) AS "SUBQUERY_1" LIMIT 1
+           |""".stripMargin,
+        pushDf,
+      )
+      val approxCount = pushDf.collect().head.getLong(0)
+      // approx_count_distinct is not accurate, so we just check the range
+      assert(approxCount > 90 && approxCount < 130)
+    }
+
+    {
+      val pushDf = tmpDF.selectExpr("approx_count_distinct(i)")
+      testPushdownSql(
+        s"""
+           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+           |FROM (
+           |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
+           |  FROM (
+           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |  ) AS "SUBQUERY_1" LIMIT 1
+           |""".stripMargin,
+        pushDf,
+      )
+      val approxCount = pushDf.collect().head.getLong(0)
+      // approx_count_distinct is not accurate, so we just check the range
+      assert(approxCount > 50 && approxCount < 90)
+    }
   }
 
   override def beforeEach(): Unit = {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
@@ -37,6 +37,11 @@ private[querygeneration] object AggregationStatement {
                 blockStatement(
                   distinct + convertStatements(fields, agg_fun.children: _*)
                 )
+            case _: HyperLogLogPlusPlus =>
+              // NOTE: We are not passing through the other parameters in Spark's HLL
+              // like mutableAggBufferOffset and inputAggBufferOffset
+              ConstantString("HLL") +
+                blockStatement(convertStatements(fields, agg_fun.children: _*))
             case _ =>
               // This exception is not a real issue. It will be caught in
               // QueryBuilder.treeRoot and a telemetry message will be sent if


### PR DESCRIPTION
Adding pushdown for `approx_count_distinct` (which internally is called HyperLogLog HLL). Note the one in Spark has some [extra values here](https://github.com/ActionIQ/flame/blob/0945baf90660a101ae0f86a39d4c91ca74ae5ee3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala#L59-L64), I'm not passing those through. I *think* its ok because it still ends up doing the same basic function.

### Test Notes
```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI

sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01
sbt it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02
```

### Deploy Notes
`sbt publish`