### PR TITLE
[EXE-1940] Adding `AiqDayDiff` PushDown to Snowflake Connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq40"
+val sparkVersion = "3-3-2-aiq60"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq6"
+val sparkConnectorVersion = "2.11.3-aiq7"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -298,7 +298,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
         |(1693609200000, 1693616400000, 'UTC'),
         |(1693609200000, 1693616400000, 'EST'),
         |(1693609200000, NULL, 'UTC'),
-        |(NULL, 1693616400000, NULL),
+        |(NULL, 1693616400000, 'UTC'),
         |(1693609200000, 1693616400000, NULL)
         |""".stripMargin.linesIterator.mkString(" ").trim
     )

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -317,7 +317,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT (
          |  DATEDIFF (
-         |    day ,
+         |    'day' ,
          |    TO_TIMESTAMP (
          |      CONVERT_TIMEZONE (
          |        "SUBQUERY_0"."TZ" ,

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -296,7 +296,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     jdbcUpdate(s"insert into $test_table_date values " +
       s"""
         |(1693609200000, 1693616400000, 'UTC'),
-        |(1693609200000, 1693616400000, 'EST')
+        |(1693609200000, 1693616400000, 'EST'),
+        |(1693609200000, NULL, 'UTC')
         |""".stripMargin.linesIterator.mkString(" ").trim
     )
 
@@ -311,6 +312,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val expectedResult = Seq(
       Row(1L),
       Row(0L),
+      Row(null),
     )
 
     testPushdown(

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -297,7 +297,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
         |(1693609200000, 1693616400000, 'UTC'),
         |(1693609200000, 1693616400000, 'EST'),
-        |(1693609200000, NULL, 'UTC')
+        |(1693609200000, NULL, 'UTC'),
+        |(NULL, 1693616400000, NULL),
+        |(1693609200000, 1693616400000, NULL)
         |""".stripMargin.linesIterator.mkString(" ").trim
     )
 
@@ -312,6 +314,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val expectedResult = Seq(
       Row(1L),
       Row(0L),
+      Row(null),
+      Row(null),
       Row(null),
     )
 

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -204,7 +204,7 @@ private[querygeneration] object DateStatement {
       ---   """select aiq_day_diff(1693609200000, 1693616400000, 'UTC')"""
       --- ).as[Long].collect.head == 1
       select DATEDIFF(
-        "DAY",
+        'day',
         TO_TIMESTAMP(
           CONVERT_TIMEZONE(
             'UTC',

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -249,7 +249,7 @@ private[querygeneration] object DateStatement {
         functionStatement(
           "DATEDIFF",
           Seq(
-            ConstantString("day").toStatement,
+            ConstantString("'day'").toStatement,
             startTimestampStm,
             endTimestampStm,
           )

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -1,7 +1,7 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
 import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{AddMonths, AiqDateToString, AiqDayStart, AiqStringToDate, Attribute, DateAdd, DateSub, Expression, Month, Quarter, TruncDate, TruncTimestamp, Year}
+import org.apache.spark.sql.catalyst.expressions.{AddMonths, AiqDateToString, AiqDayDiff, AiqDayStart, AiqStringToDate, Attribute, DateAdd, DateSub, Expression, Month, Quarter, TruncDate, TruncTimestamp, Year}
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object DateStatement {
@@ -195,6 +195,63 @@ private[querygeneration] object DateStatement {
               )
             ),
             ConstantString(s"'$format'").toStatement,
+          )
+        )
+
+      /*
+      --- 2023-09-01 to 2023-09-02
+      --- spark.sql(
+      ---   """select aiq_day_diff(1693609200000, 1693616400000, 'UTC')"""
+      --- ).as[Long].collect.head == 1
+      select DATEDIFF(
+        "DAY",
+        TO_TIMESTAMP(
+          CONVERT_TIMEZONE(
+            'UTC',
+            1693609200000::varchar
+          )
+        ),
+        TO_TIMESTAMP(
+          CONVERT_TIMEZONE(
+            'UTC',
+            1693616400000::varchar
+          )
+        )
+      )
+      -- 1
+      */
+      case AiqDayDiff(startTimestampLong, endTimestampLong, timezoneStr) =>
+        val startTimestampStm = functionStatement(
+          "TO_TIMESTAMP",
+          Seq(
+            functionStatement(
+              "CONVERT_TIMEZONE",
+              Seq(
+                convertStatement(timezoneStr, fields),
+                convertStatement(startTimestampLong, fields) + ConstantString("::varchar"),
+              ),
+            )
+          )
+        )
+        val endTimestampStm = functionStatement(
+          "TO_TIMESTAMP",
+          Seq(
+            functionStatement(
+              "CONVERT_TIMEZONE",
+              Seq(
+                convertStatement(timezoneStr, fields),
+                convertStatement(endTimestampLong, fields) + ConstantString("::varchar"),
+              ),
+            )
+          )
+        )
+
+        functionStatement(
+          "DATEDIFF",
+          Seq(
+            ConstantString("day").toStatement,
+            startTimestampStm,
+            endTimestampStm,
           )
         )
 


### PR DESCRIPTION
Adding the Snowflake Connector part for the Flame PR https://github.com/ActionIQ/flame/pull/508 that introduced `AiqDayDiff`

Equivalent BigQuery PR: https://github.com/ActionIQ/spark-bigquery-connector/pull/12

## Test Notes
```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01" >> /Users/yannis.tzemos/D
ocuments/CodeSnips/snow_test_output_1.txt
...
[info] Run completed in 1 minute, 6 seconds.
[info] Total number of tests run: 20
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 70 s (01:10), completed Jan 10, 2024, 1:12:25 AM
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_2.txt
...
[info] - test pushdown number functions: PI() and Round()/Random
[info] - AIQ test pushdown day_start
[info] - AIQ test pushdown day_diff
[info] - AIQ test pushdown instr
[info] - AIQ test pushdown string_to_date
[info] - AIQ test pushdown date_to_string
[info] - test pushdown functions date_add/date_sub
[info] - test pushdown functions date_add/date_sub on Feb last day in leap and non-leap year
[info] - test pushdown WindowExpression: Rank without PARTITION BY
[info] - test pushdown WindowExpression: Rank with PARTITION BY
[info] - test pushdown WindowExpression: DenseRank without PARTITION BY
[info] - test pushdown WindowExpression: DenseRank with PARTITION BY
[info] - literal Date/Timestamp
[info] - test literal null
[info] - AIQ test approx_count_dist
[info] Run completed in 1 minute, 35 seconds.
[info] Total number of tests run: 17
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 17, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 97 s (01:37), completed Jan 10, 2024, 1:14:32 AM
```

## Deploy Notes
- `sbt publish` 
- Pick up the new Connector version in Flame