### PR TITLE
[EXE-2212] Update Snowflake Connector with missing Functions PushDown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq7"
+val sparkConnectorVersion = "2.11.3-aiq8"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -343,17 +343,16 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
   }
 
-
   test("AIQ test pushdown instr") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"('hello world')")
 
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr(
@@ -383,7 +382,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT ( CHARINDEX ( 'hell' , "SUBQUERY_0"."S" )
          |  ) AS "SUBQUERY_1_COL_0" FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |  ) AS "SUBQUERY_0"
          |""".stripMargin,
       pushDf,
@@ -563,9 +562,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown md5") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"""
          |('snowflake'),
          |('spark'),
@@ -577,7 +576,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr("md5(s)", "md5(concat(s,s))")
@@ -602,7 +601,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  )
          |) AS "SUBQUERY_1_COL_1"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -611,9 +610,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown sha1") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"""
          |('snowflake'),
          |('spark'),
@@ -625,7 +624,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr("sha1(s)", "sha1(concat(s,s))")
@@ -650,7 +649,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  )
          |) AS "SUBQUERY_1_COL_1"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -659,9 +658,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown sha2") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"""
          |('snowflake'),
          |('spark'),
@@ -673,7 +672,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr("sha2(s, 224)", "sha2(concat(s,s), 224)")
@@ -709,7 +708,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  )
          |) AS "SUBQUERY_1_COL_1"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -718,9 +717,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown reverse") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"""
          |('snowflake'),
          |('spark'),
@@ -732,7 +731,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr("reverse(s)", "reverse(concat(s,s))")
@@ -749,7 +748,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  ( REVERSE ( "SUBQUERY_0"."S" ) ) AS "SUBQUERY_1_COL_0" ,
          |  ( REVERSE ( CONCAT ( "SUBQUERY_0"."S" , "SUBQUERY_0"."S" ) ) ) AS "SUBQUERY_1_COL_1"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -758,9 +757,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown concat_ws") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"""
          |('snowflake'),
          |('spark'),
@@ -772,7 +771,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr(
@@ -805,7 +804,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |    COALESCE ( CONCAT_WS ( '/' , "SUBQUERY_0"."S" , "SUBQUERY_0"."S" , "SUBQUERY_0"."S" ) , '' )
          |  ) ) AS "SUBQUERY_1_COL_3"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -814,15 +813,15 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown generate_uuid") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_string " +
       s"(s string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
+    jdbcUpdate(s"insert into $test_table_string values " +
       s"('produced id')")
 
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_string)
       .load()
 
     val resultDF = tmpDF.selectExpr("concat_ws(' : ', s, uuid())")
@@ -832,7 +831,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |SELECT
          |  ( COALESCE ( CONCAT_WS ( ' : ' , "SUBQUERY_0"."S" , UUID_STRING ( ) ) , '' ) ) AS "SUBQUERY_1_COL_0"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
@@ -840,9 +839,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown rand") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_number " +
       s"(i integer)")
-    jdbcUpdate(s"insert into $test_table_date values" +
+    jdbcUpdate(s"insert into $test_table_number values" +
       s"""
          |(1),
          |(2),
@@ -854,7 +853,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_number)
       .load()
 
     val resultDFSelect = tmpDF.selectExpr("i * rand(0)")
@@ -864,7 +863,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  ( CAST ( "SUBQUERY_0"."I" AS DOUBLE ) * UNIFORM ( 0::float , 1::float , RANDOM ( 0 ) ) )
          |) AS "SUBQUERY_1_COL_0"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_number ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFSelect,
@@ -877,7 +876,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT * FROM
          |(
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |  SELECT * FROM ( $test_table_number ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
          |  WHERE (
          |    ( "SUBQUERY_0"."I" IS NOT NULL ) AND
          |    ( CAST ( "SUBQUERY_0"."I" AS DOUBLE ) > UNIFORM ( 0::float , 1::float , RANDOM ( 0 ) )
@@ -891,9 +890,9 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
   }
 
   test("AIQ test pushdown log") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
+    jdbcUpdate(s"create or replace table $test_table_number " +
       s"(i number)")
-    jdbcUpdate(s"insert into $test_table_date values" +
+    jdbcUpdate(s"insert into $test_table_number values" +
       s"""
          |(2.0),
          |(3.0),
@@ -905,7 +904,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     val tmpDF = sparkSession.read
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
+      .option("dbtable", test_table_number)
       .load()
 
     val resultDFStaticBase = tmpDF.selectExpr("round(log(2, i), 2)")
@@ -922,7 +921,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  ROUND ( LOG ( 2.0 , ( CAST ( "SUBQUERY_0"."I" AS DOUBLE ) ) ) , 2 )
          |) AS "SUBQUERY_1_COL_0"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_number ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFStaticBase,
@@ -945,11 +944,81 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  )
          |) AS "SUBQUERY_1_COL_0"
          |FROM (
-         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |  SELECT * FROM ( $test_table_number ) AS "SF_CONNECTOR_QUERY_ALIAS"
          |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFDynamicBase,
       expectedResultDynamicBase,
+    )
+  }
+
+  test("AIQ test pushdown format_number") {
+    jdbcUpdate(s"create or replace table $test_table_string " +
+      s"(i float)")
+    jdbcUpdate(s"insert into $test_table_string values" +
+      s"""
+         |(5.0000),
+         |(3.00000000),
+         |(4444444.0),
+         |(4444444.12342134),
+         |(44444444444.12342134),
+         |(NULL)
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_string)
+      .load()
+
+    val resultDF = tmpDF.selectExpr(
+      "format_number(i, 4)",
+      "format_number(i, 2)",
+      "format_number(i, 0)",
+    )
+    val expectedResult = Seq(
+      Row("5.0000", "5.00", "5"),
+      Row("3.0000", "3.00", "3"),
+      Row("4,444,444.0000", "4,444,444.00", "4,444,444"),
+      Row("4,444,444.1234", "4,444,444.12", "4,444,444"),
+      Row("44,444,444,444.1234", "44,444,444,444.12", "44,444,444,444"),
+      Row(null, null, null),
+    )
+
+    testPushdown(
+      s"""
+         |SELECT
+         |(
+         |  TRIM (
+         |    TO_VARCHAR (
+         |      TO_NUMERIC ( CAST ( "SUBQUERY_0"."I" AS VARCHAR ) , 'TM9' , 38 , 4 ) ,
+         |      '9,999,999,999,999,999,999.0000'
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_0" ,
+         |(
+         |  TRIM (
+         |    TO_VARCHAR (
+         |      TO_NUMERIC ( CAST ( "SUBQUERY_0"."I" AS VARCHAR ) , 'TM9' , 38 , 2 ) ,
+         |      '9,999,999,999,999,999,999.00'
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_1" ,
+         |(
+         |  TRIM (
+         |    TO_VARCHAR (
+         |      TO_NUMERIC ( CAST ( "SUBQUERY_0"."I" AS VARCHAR ) , 'TM9' , 38 , 0 ) ,
+         |      '9,999,999,999,999,999,999'
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_2"
+         |FROM (
+         |  SELECT * FROM ( $test_table_string ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      resultDF,
+      expectedResult,
     )
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -775,6 +775,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       .load()
 
     val resultDF = tmpDF.selectExpr(
+      "concat_ws('|')",
       "concat_ws('|', s)",
       "concat_ws('|', s, s)",
       "concat_ws('/', s, s, s)",
@@ -784,6 +785,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
     val expectedResult = Seq(
       Row(
+        "",
         "snowflake",
         "snowflake|snowflake",
         "snowflake/snowflake/snowflake",
@@ -792,6 +794,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
         "ekalfwons/ekalfwons/ekalfwons"
       ),
       Row(
+        "",
         "spark",
         "spark|spark",
         "spark/spark/spark",
@@ -799,8 +802,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
         "spark/spark/spark/a",
         "kraps/kraps/kraps"
       ),
-      Row("", "|", "//", null, "///a", "//"),
-      Row("", "", "", null, "a", ""),
+      Row("", "", "|", "//", null, "///a", "//"),
+      Row("", "", "", "", null, "a", ""),
     )
 
     testPushdown(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/CryptographicStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/CryptographicStatement.scala
@@ -35,6 +35,7 @@ private[querygeneration] object CryptographicStatement {
     val fields = expAttr._2
 
     Option(expr match {
+      // https://docs.snowflake.com/en/sql-reference/functions/md5
       case Md5(child) =>
         child match {
           // Spark always casts child to binary, need to use string for Snowflake otherwise
@@ -49,6 +50,7 @@ private[querygeneration] object CryptographicStatement {
           case _ => null
         }
 
+      // https://docs.snowflake.com/en/sql-reference/functions/sha1
       case Sha1(child) =>
         child match {
           // Spark always casts child to binary, need to use string for Snowflake otherwise
@@ -63,6 +65,7 @@ private[querygeneration] object CryptographicStatement {
           case _ => null
         }
 
+      // https://docs.snowflake.com/en/sql-reference/functions/sha2
       case Sha2(left, right) =>
         left match {
           // Spark always casts child to binary, need to use string for Snowflake otherwise

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/CryptographicStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/CryptographicStatement.scala
@@ -1,0 +1,84 @@
+package net.snowflake.spark.snowflake.pushdowns.querygeneration
+
+import net.snowflake.spark.snowflake._
+
+import scala.language.postfixOps
+import org.apache.spark.sql.catalyst.expressions.{
+  Attribute,
+  Cast,
+  Expression,
+  Md5,
+  Sha1,
+  Sha2
+}
+import org.apache.spark.sql.types.{BinaryType, StringType}
+
+/**
+ * Extractor for basic (attributes and literals) expressions.
+ */
+private[querygeneration] object CryptographicStatement {
+
+  /** Used mainly by QueryGeneration.convertExpression. This matches
+   * a tuple of (Expression, Seq[Attribute]) representing the expression to
+   * be matched and the fields that define the valid fields in the current expression
+   * scope, respectively.
+   *
+   * @param expAttr A pair-tuple representing the expression to be matched and the
+   *                attribute fields.
+   * @return An option containing the translated SQL, if there is a match, or None if there
+   *         is no match.
+   */
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[SnowflakeSQLStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case Md5(child) =>
+        child match {
+          // Spark always casts child to binary, need to use string for Snowflake otherwise
+          // we get: `The following string is not a legal hex-encoded value` error
+          case Cast(c, _: BinaryType, tZ, ansiEn) =>
+            functionStatement(
+              "MD5",
+              Seq(
+                convertStatement(Cast(c, StringType, tZ, ansiEn), fields)
+              ),
+            )
+          case _ => null
+        }
+
+      case Sha1(child) =>
+        child match {
+          // Spark always casts child to binary, need to use string for Snowflake otherwise
+          // we get: `The following string is not a legal hex-encoded value` error
+          case Cast(c, _: BinaryType, tZ, ansiEn) =>
+            functionStatement(
+              "SHA1",
+              Seq(
+                convertStatement(Cast(c, StringType, tZ, ansiEn), fields)
+              ),
+            )
+          case _ => null
+        }
+
+      case Sha2(left, right) =>
+        left match {
+          // Spark always casts child to binary, need to use string for Snowflake otherwise
+          // we get: `The following string is not a legal hex-encoded value` error
+          case Cast(l, _: BinaryType, tZ, ansiEn) =>
+            functionStatement(
+              "SHA2",
+              Seq(
+                convertStatement(Cast(l, StringType, tZ, ansiEn), fields),
+                convertStatement(right, fields),
+              ),
+            )
+          case _ => null
+        }
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
@@ -1,39 +1,9 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{
-  ConstantString,
-  LongVariable,
-  SnowflakeSQLStatement
-}
+import net.snowflake.spark.snowflake.{ConstantString, LongVariable, SnowflakeSQLStatement}
+
 import scala.language.postfixOps
-import org.apache.spark.sql.catalyst.expressions.{
-  Abs,
-  Acos,
-  Asin,
-  Atan,
-  Attribute,
-  Ceil,
-  CheckOverflow,
-  Cos,
-  Cosh,
-  Exp,
-  Expression,
-  Floor,
-  Greatest,
-  Least,
-  Log,
-  Pi,
-  Pow,
-  PromotePrecision,
-  Rand,
-  Round,
-  Sin,
-  Sinh,
-  Sqrt,
-  Tan,
-  Tanh,
-  UnaryMinus
-}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Asin, Atan, Attribute, Ceil, CheckOverflow, Cos, Cosh, Exp, Expression, Floor, Greatest, Least, Log, Pi, Pow, PromotePrecision, Rand, Round, Sin, Sinh, Sqrt, Tan, Tanh, UnaryMinus}
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object NumericStatement {
@@ -56,9 +26,13 @@ private[querygeneration] object NumericStatement {
 
     Option(expr match {
       case _: Abs | _: Acos | _: Cos | _: Tan | _: Tanh | _: Cosh | _: Atan |
-          _: Floor | _: Sin | _: Log | _: Asin | _: Sqrt | _: Ceil | _: Sqrt |
+          _: Floor | _: Sin | _: Asin | _: Sqrt | _: Ceil | _: Sqrt |
           _: Sinh | _: Greatest | _: Least | _: Exp =>
         ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatements(fields, expr.children: _*))
+
+      case Log(child) =>
+        ConstantString("LOG") +
           blockStatement(convertStatements(fields, expr.children: _*))
 
       // From spark 3.1, UnaryMinus() has 2 parameters.
@@ -89,11 +63,30 @@ private[querygeneration] object NumericStatement {
       // Suppose connector can't see Pi().
       case Pi() => ConstantString("PI()") !
 
-      // From spark 3.1, Rand() has 2 parameters.
       case Rand(seed, _) =>
-        ConstantString("RANDOM") + blockStatement(
-          LongVariable(Option(seed).map(_.asInstanceOf[Long])) !
-        )
+        seed match {
+          case _: Expression =>
+            // Spark follows the following Snowflake equivalent:
+            //  uniform(0::float, 1::float, random())
+            functionStatement(
+              "UNIFORM",
+              Seq(
+                ConstantString("0::float").toStatement,
+                ConstantString("1::float").toStatement,
+                functionStatement(
+                  "RANDOM",
+                  Seq(convertStatement(seed, fields)),
+                ),
+              ),
+            )
+          // default to old method if new one isn't applicable
+          case _ =>
+            // From spark 3.1, Rand() has 2 parameters.
+            ConstantString("RANDOM") + blockStatement(
+              LongVariable(Option(seed).map(_.asInstanceOf[Long])) !
+            )
+        }
+
       case Round(child, scale) =>
         ConstantString("ROUND") + blockStatement(
           convertStatements(fields, child, scale)

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/NumericStatement.scala
@@ -31,7 +31,7 @@ private[querygeneration] object NumericStatement {
         ConstantString(expr.prettyName.toUpperCase) +
           blockStatement(convertStatements(fields, expr.children: _*))
 
-      case Log(child) =>
+      case _: Log =>
         ConstantString("LOG") +
           blockStatement(convertStatements(fields, expr.children: _*))
 
@@ -79,7 +79,7 @@ private[querygeneration] object NumericStatement {
                 ),
               ),
             )
-          // default to old method if new one isn't applicable
+          // default to original implementation if new one isn't applicable
           case _ =>
             // From spark 3.1, Rand() has 2 parameters.
             ConstantString("RANDOM") + blockStatement(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -47,6 +47,10 @@ private[querygeneration] object StringStatement {
         )
 
       // https://docs.snowflake.com/en/sql-reference/functions/concat_ws
+      // Trying to make `concat_ws` work is not possible so adjusting with the
+      // Snowflake functions below that do the trick and support the behavior
+      // https://docs.snowflake.com/en/sql-reference/functions/array_to_string
+      // https://docs.snowflake.com/en/sql-reference/functions/array_construct_compact
       case ConcatWs(children) =>
         if (children.length >= 2) {
           val separator = children.head

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -71,6 +71,7 @@ private[querygeneration] object StringStatement {
             convertStatement(rightSide, fields)
         )
 
+      // https://docs.snowflake.com/en/sql-reference/functions/concat_ws
       case ConcatWs(children) =>
         if (children.length >= 2) {
           val separator = children.head
@@ -128,6 +129,7 @@ private[querygeneration] object StringStatement {
           case _ => null
         }
 
+      // https://docs.snowflake.com/en/sql-reference/functions/uuid_string
       case _: Uuid => functionStatement("UUID_STRING", Seq())
 
       case _ => null

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -1,7 +1,7 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{ConstantString, SnowflakeFailMessage, SnowflakePushdownUnsupportedException, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{Ascii, Attribute, Cast, Coalesce, Concat, ConcatWs, Expression, FormatNumber, Length, Like, Literal, Lower, Reverse, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Upper, Uuid}
+import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
+import org.apache.spark.sql.catalyst.expressions.{Ascii, Attribute, Cast, Concat, ConcatWs, Expression, FormatNumber, Length, Like, Literal, Lower, Reverse, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Upper, Uuid}
 import org.apache.spark.sql.types.StringType
 
 /** Extractor for boolean expressions (return true or false). */
@@ -50,26 +50,26 @@ private[querygeneration] object StringStatement {
       case ConcatWs(children) =>
         if (children.length >= 2) {
           val separator = children.head
-          val snowStm = children.drop(1).foldLeft(convertStatement(separator, fields)) {
+          val firstStmt = children(1)
+          val snowStm = children.drop(2).foldLeft(convertStatement(firstStmt, fields)) {
             (currentSnowStm, nextExpr) => mkStatement(
-              Seq(
-                currentSnowStm,
-                // Wrapping around Coalesce to mimic Spark's behavior =>
-                //  in case of null, return empty string ('')
-                convertStatement(Coalesce(Seq(nextExpr, Literal(""))), fields)
-              ),
+              Seq(currentSnowStm, convertStatement(nextExpr, fields)),
               ","
             )
           }
 
-          functionStatement(expr.prettyName.toUpperCase, Seq(snowStm))
-        } else {
-          throw new SnowflakePushdownUnsupportedException(
-            SnowflakeFailMessage.FAIL_PUSHDOWN_UNSUPPORTED_CONVERSION,
-            "Not enough arguments for function [CONCAT_WS(',')], expected 2, got 1",
-            "",
-            false
+          functionStatement(
+            "ARRAY_TO_STRING",
+            Seq(
+              functionStatement(
+                "ARRAY_CONSTRUCT_COMPACT",
+                Seq(snowStm),
+              ),
+              convertStatement(separator, fields),
+            )
           )
+        } else {
+          convertStatement(Literal(""), fields)
         }
 
       // ESCAPE Char is supported from Spark 3.0

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -1,6 +1,11 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{ConstantString, SnowflakeFailMessage, SnowflakePushdownUnsupportedException, SnowflakeSQLStatement}
+import net.snowflake.spark.snowflake.{
+  ConstantString,
+  SnowflakeFailMessage,
+  SnowflakePushdownUnsupportedException,
+  SnowflakeSQLStatement
+}
 import org.apache.spark.sql.catalyst.expressions.{
   Ascii,
   Attribute,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -1,7 +1,33 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{Ascii, Attribute, Cast, Concat, ConcatWs, Expression, FormatNumber, Length, Like, Literal, Lower, Reverse, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Upper, Uuid}
+import net.snowflake.spark.snowflake.{
+  ConstantString,
+  SnowflakeSQLStatement
+}
+import org.apache.spark.sql.catalyst.expressions.{
+  Ascii,
+  Attribute,
+  Cast,
+  Concat,
+  ConcatWs,
+  Expression,
+  FormatNumber,
+  Length,
+  Like,
+  Literal,
+  Lower,
+  Reverse,
+  StringInstr,
+  StringLPad,
+  StringRPad,
+  StringTranslate,
+  StringTrim,
+  StringTrimLeft,
+  StringTrimRight,
+  Substring,
+  Upper,
+  Uuid
+}
 import org.apache.spark.sql.types.StringType
 
 /** Extractor for boolean expressions (return true or false). */

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/StringStatement.scala
@@ -115,8 +115,9 @@ private[querygeneration] object StringStatement {
         ) + escapeClause
 
       // https://docs.snowflake.com/en/sql-reference/functions/reverse
-      // Reverse in Snowflake only supports StringType and DateType
-      // which Spark doesn't
+      // Reverse in Snowflake only supports StringType and DateType.
+      // Spark only supports StringType and ArrayType, thus we only
+      // implement for StringType
       case Reverse(child) =>
         child.dataType match {
           case _: StringType =>

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/package.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/package.scala
@@ -107,6 +107,7 @@ package object querygeneration {
       case AggregationStatement(stmt) => stmt
       case BasicStatement(stmt) => stmt
       case BooleanStatement(stmt) => stmt
+      case CryptographicStatement(stmt) => stmt
       case DateStatement(stmt) => stmt
       case MiscStatement(stmt) => stmt
       case NumericStatement(stmt) => stmt


### PR DESCRIPTION
Adding missing PushDown Support for the following functions:

- `md5`
- `sha1`
- `sha2`
- `reverse`
- `concat_ws`
- `generate_uuid`
- `rand`
- `log`
- `format_number`

## Test Notes
```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_1.txt
...
[info] - test pushdown IN() function
[info] - test pushdown INSET() function
[info] - test pushdown INSET() function with timestamps and double
[info] - test pushdown COALESCE()
[info] - pushdown EqualNullSafe: operator <=>
[info] Run completed in 1 minute, 16 seconds.
[info] Total number of tests run: 20
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 80 s (01:20), completed Jan 12, 2024, 8:00:04 PM
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_2.txt
...
[info] - test pushdown number functions: PI() and Round()/Random
[info] - AIQ test pushdown day_start
[info] - AIQ test pushdown day_diff
[info] - AIQ test pushdown instr
[info] - AIQ test pushdown string_to_date
[info] - AIQ test pushdown date_to_string
[info] - AIQ test pushdown md5
[info] - AIQ test pushdown sha1
[info] - AIQ test pushdown sha2
[info] - AIQ test pushdown reverse
[info] - AIQ test pushdown concat_ws
[info] - AIQ test pushdown generate_uuid
[info] - AIQ test pushdown rand
[info] - AIQ test pushdown log
[info] - AIQ test pushdown format_number
[info] - test pushdown functions date_add/date_sub
[info] - test pushdown functions date_add/date_sub on Feb last day in leap and non-leap year
[info] - test pushdown WindowExpression: Rank without PARTITION BY
[info] - test pushdown WindowExpression: Rank with PARTITION BY
[info] - test pushdown WindowExpression: DenseRank without PARTITION BY
[info] - test pushdown WindowExpression: DenseRank with PARTITION BY
[info] - literal Date/Timestamp
[info] - test literal null
[info] - AIQ test approx_count_dist
[info] Run completed in 2 minutes, 1 second.
[info] Total number of tests run: 26
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 26, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 122 s (02:02), completed Jan 12, 2024, 8:02:46 PM
```

## Deploy
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters