### PR TITLE
[EXE-1946][EXE-2278] Adding `AiqWeekDiff` and `CollectSet` PushDown Functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq60"
+val sparkVersion = "3-3-2-aiq68"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq8"
+val sparkConnectorVersion = "2.11.3-aiq9"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -471,7 +471,10 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFStr
     )
-    assert(resultDFStr.collect().head.get(0).asInstanceOf[Seq[String]].length == 3L)
+    assert(
+      resultDFStr.collect().head.get(0).asInstanceOf[Seq[String]].sorted ==
+        Seq("hello this is a test", "hello this is a test1", "hello this is a test2").sorted
+    )
 
     testPushdownSql(
       s"""
@@ -487,7 +490,15 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFInt
     )
-    assert(resultDFStr.collect().head.get(0).asInstanceOf[Seq[Int]].length == 3L)
+    assert(
+      resultDFInt
+        .collect()
+        .head
+        .get(0)
+        .asInstanceOf[Seq[java.math.BigDecimal]]
+        .map(_.intValue)
+        .sorted == Seq(1, 2, 3).sorted
+    )
   }
 
   test("AIQ test pushdown instr") {

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -471,6 +471,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFStr
     )
+    assert(resultDFStr.collect().head.get(0).asInstanceOf[Seq[String]].length == 3L)
 
     testPushdownSql(
       s"""
@@ -486,6 +487,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDFInt
     )
+    assert(resultDFStr.collect().head.get(0).asInstanceOf[Seq[Int]].length == 3L)
   }
 
   test("AIQ test pushdown instr") {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/AggregationStatement.scala
@@ -42,6 +42,11 @@ private[querygeneration] object AggregationStatement {
               // like mutableAggBufferOffset and inputAggBufferOffset
               ConstantString("HLL") +
                 blockStatement(convertStatements(fields, agg_fun.children: _*))
+            case _: CollectSet =>
+              functionStatement(
+                "ARRAY_AGG",
+                Seq(ConstantString("DISTINCT") + convertStatements(fields, agg_fun.children: _*))
+              )
             case _ =>
               // This exception is not a real issue. It will be caught in
               // QueryBuilder.treeRoot and a telemetry message will be sent if

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -1,7 +1,31 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, AiqDateToString, AiqDayDiff, AiqDayStart, AiqStringToDate, AiqWeekDiff, Attribute, DateAdd, DateSub, Divide, Expression, Floor, Literal, Month, Quarter, Subtract, TruncDate, TruncTimestamp, Year}
+import net.snowflake.spark.snowflake.{
+  ConstantString,
+  SnowflakeSQLStatement
+}
+import org.apache.spark.sql.catalyst.expressions.{
+  Add,
+  AddMonths,
+  AiqDateToString,
+  AiqDayDiff,
+  AiqDayStart,
+  AiqStringToDate,
+  AiqWeekDiff,
+  Attribute,
+  DateAdd,
+  DateSub,
+  Divide,
+  Expression,
+  Floor,
+  Literal,
+  Month,
+  Quarter,
+  Subtract,
+  TruncDate,
+  TruncTimestamp,
+  Year
+}
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object DateStatement {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -1,7 +1,30 @@
 package net.snowflake.spark.snowflake.pushdowns.querygeneration
 
-import net.snowflake.spark.snowflake.{ConstantString, SnowflakeSQLStatement}
-import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, AiqDateToString, AiqDayDiff, AiqDayStart, AiqStringToDate, AiqWeekDiff, Attribute, BinaryOperator, DateAdd, DateSub, Divide, Expression, Floor, Literal, Month, Quarter, TruncDate, TruncTimestamp, Year}
+import net.snowflake.spark.snowflake.{
+  ConstantString,
+  SnowflakeSQLStatement
+}
+import org.apache.spark.sql.catalyst.expressions.{
+  Add,
+  AddMonths,
+  AiqDateToString,
+  AiqDayDiff,
+  AiqDayStart,
+  AiqStringToDate,
+  AiqWeekDiff,
+  Attribute,
+  DateAdd,
+  DateSub,
+  Divide,
+  Expression,
+  Floor,
+  Literal,
+  Month,
+  Quarter,
+  TruncDate,
+  TruncTimestamp,
+  Year
+}
 
 /** Extractor for boolean expressions (return true or false). */
 private[querygeneration] object DateStatement {

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -303,28 +303,32 @@ private[querygeneration] object DateStatement {
      --- spark.sql(
      ---   """select aiq_week_diff(1551880107963, 1553890107963, 'sunday', 'UTC')"""
      --- ).as[Long].collect.head == 3
-     select
-      (
-        (
-          (
-            DATEDIFF (
-              'day',
-              TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', 0::varchar)) ,
-              TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', 1551880107963::varchar))
-            ) + 4
-          ) / 7
-        )
-        -
-        (
-          (
-            DATEDIFF (
-              'day' ,
-              TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', 0::varchar)),
-              TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', 1553890107963::varchar))
-            ) + 4
-          ) / 7
-        )
-      ) ::int
+     select (
+       (
+         FLOOR (
+           (
+             (
+               DATEDIFF (
+                 'day' ,
+                 TO_TIMESTAMP(CONVERT_TIMEZONE ('UTC', 0::varchar)),
+                 TO_TIMESTAMP(CONVERT_TIMEZONE ('UTC', 1551880107963::varchar))
+               ) + 4
+             ) / 7
+           )
+         )
+         -
+         FLOOR (
+           (
+             (
+               DATEDIFF (
+                 'day' ,
+                 TO_TIMESTAMP (CONVERT_TIMEZONE('UTC' , 0::varchar)),
+                 TO_TIMESTAMP (CONVERT_TIMEZONE('UTC' , 1553890107963::varchar))
+               ) + 4
+             ) / 7
+           )
+         )
+       )
      -- 3
      */
       case AiqWeekDiff(startTimestampLong, endTimestampLong, startDayStr, timezoneStr)

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -8,6 +8,7 @@ import net.snowflake.spark.snowflake.{
   SnowflakePushdownUnsupportedException,
   SnowflakeSQLStatement
 }
+import org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet
 import org.apache.spark.sql.catalyst.expressions.{
   Alias,
   Ascending,
@@ -145,6 +146,12 @@ private[querygeneration] object MiscStatement {
               ", "
             )
           )
+
+      case CollectSet(child, _, _) =>
+        functionStatement(
+          "ARRAY_AGG",
+          Seq(ConstantString("DISTINCT") + convertStatement(child, fields))
+        )
 
       case _ => null
     })

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -8,7 +8,6 @@ import net.snowflake.spark.snowflake.{
   SnowflakePushdownUnsupportedException,
   SnowflakeSQLStatement
 }
-import org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet
 import org.apache.spark.sql.catalyst.expressions.{
   Alias,
   Ascending,
@@ -146,12 +145,6 @@ private[querygeneration] object MiscStatement {
               ", "
             )
           )
-
-      case CollectSet(child, _, _) =>
-        functionStatement(
-          "ARRAY_AGG",
-          Seq(ConstantString("DISTINCT") + convertStatement(child, fields))
-        )
 
       case _ => null
     })


### PR DESCRIPTION
Adding missing PushDown Support for the following functions:

- `aiq_week_diff`
- `collect_set`

## Test Notes
```
-> % sbt compile
...
[success] Total time: 1 s, completed Feb 9, 2024, 4:19:12 PM
```

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_1.txt
...
[info] - test pushdown IN() function
[info] - test pushdown INSET() function
[info] - test pushdown INSET() function with timestamps and double
[info] - test pushdown COALESCE()
[info] - pushdown EqualNullSafe: operator <=>
[info] Run completed in 1 minute, 5 seconds.
[info] Total number of tests run: 20
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 69 s (01:09), completed Feb 9, 2024, 4:20:45 PM
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_2.txt
...
[info] - test pushdown number functions: PI() and Round()/Random
[info] - AIQ test pushdown day_start
[info] - AIQ test pushdown day_diff
[info] - AIQ test pushdown week_diff
[info] - AIQ test pushdown collect_set
[info] - AIQ test pushdown instr
[info] - AIQ test pushdown string_to_date
[info] - AIQ test pushdown date_to_string
[info] - AIQ test pushdown md5
[info] - AIQ test pushdown sha1
[info] - AIQ test pushdown sha2
[info] - AIQ test pushdown reverse
[info] - AIQ test pushdown concat_ws
[info] - AIQ test pushdown generate_uuid
[info] - AIQ test pushdown rand
[info] - AIQ test pushdown log
[info] - AIQ test pushdown format_number
[info] - test pushdown functions date_add/date_sub
[info] - test pushdown functions date_add/date_sub on Feb last day in leap and non-leap year
[info] - test pushdown WindowExpression: Rank without PARTITION BY
[info] - test pushdown WindowExpression: Rank with PARTITION BY
[info] - test pushdown WindowExpression: DenseRank without PARTITION BY
[info] - test pushdown WindowExpression: DenseRank with PARTITION BY
[info] - literal Date/Timestamp
[info] - test literal null
[info] - AIQ test approx_count_dist
[info] Run completed in 2 minutes.
[info] Total number of tests run: 28
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 28, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 121 s (02:01), completed Feb 9, 2024, 4:23:18 PM
```

## Deploy
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters