### PR TITLE
[EXE-1944] Add `AiqDayOfTheWeek` PushDown Support and DateFunctions Refactoring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,12 @@
 
 import scala.util.Properties
 
-val sparkVersion = "3-3-2-aiq68"
+val sparkVersion = "3-3-2-aiq70"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq9"
+val sparkConnectorVersion = "2.11.3-aiq10"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -1306,6 +1306,58 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     )
   }
 
+  test("AIQ test approx_count_dist") {
+    jdbcUpdate(s"create or replace table $test_table_date (s string, i int)")
+    (0 until 100).foreach { i =>
+      if (i % 5 == 0) {
+        jdbcUpdate(s"insert into $test_table_date values ('hello $i', $i)")
+      }
+      jdbcUpdate(s"insert into $test_table_date values ('hello $i', ${i.max(30)})")
+    }
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    {
+      val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
+      testPushdownSql(
+        s"""
+           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+           |FROM (
+           |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
+           |  FROM (
+           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |  ) AS "SUBQUERY_1" LIMIT 1
+           |""".stripMargin,
+        pushDf,
+      )
+      val approxCount = pushDf.collect().head.getLong(0)
+      // approx_count_distinct is not accurate, so we just check the range
+      assert(approxCount > 90 && approxCount < 130)
+    }
+
+    {
+      val pushDf = tmpDF.selectExpr("approx_count_distinct(i)")
+      testPushdownSql(
+        s"""
+           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
+           |FROM (
+           |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
+           |  FROM (
+           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+           |  ) AS "SUBQUERY_1" LIMIT 1
+           |""".stripMargin,
+        pushDf,
+      )
+      val approxCount = pushDf.collect().head.getLong(0)
+      // approx_count_distinct is not accurate, so we just check the range
+      assert(approxCount > 50 && approxCount < 90)
+    }
+  }
+
   test("test pushdown functions date_add/date_sub") {
     jdbcUpdate(s"create or replace table $test_table_date " +
       s"(d1 date)")
@@ -1708,58 +1760,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
     // ByPass query text check for COPY UNLOAD
     testPushdownMultiplefQueries(expectedQueries2, df2, expectedResult2,
       bypass = params.useCopyUnload)
-  }
-
-  test("AIQ test approx_count_dist") {
-    jdbcUpdate(s"create or replace table $test_table_date (s string, i int)")
-    (0 until 100).foreach { i =>
-      if (i % 5 == 0) {
-        jdbcUpdate(s"insert into $test_table_date values ('hello $i', $i)")
-      }
-      jdbcUpdate(s"insert into $test_table_date values ('hello $i', ${i.max(30)})")
-    }
-
-    val tmpDF = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    {
-      val pushDf = tmpDF.selectExpr("approx_count_distinct(s)")
-      testPushdownSql(
-        s"""
-           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
-           |FROM (
-           |  SELECT ( "SUBQUERY_0"."S" ) AS "SUBQUERY_1_COL_0"
-           |  FROM (
-           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |  ) AS "SUBQUERY_1" LIMIT 1
-           |""".stripMargin,
-        pushDf,
-      )
-      val approxCount = pushDf.collect().head.getLong(0)
-      // approx_count_distinct is not accurate, so we just check the range
-      assert(approxCount > 90 && approxCount < 130)
-    }
-
-    {
-      val pushDf = tmpDF.selectExpr("approx_count_distinct(i)")
-      testPushdownSql(
-        s"""
-           |SELECT ( HLL ( "SUBQUERY_1"."SUBQUERY_1_COL_0" ) ) AS "SUBQUERY_2_COL_0"
-           |FROM (
-           |  SELECT ( "SUBQUERY_0"."I" ) AS "SUBQUERY_1_COL_0"
-           |  FROM (
-           |    SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-           |  ) AS "SUBQUERY_1" LIMIT 1
-           |""".stripMargin,
-        pushDf,
-      )
-      val approxCount = pushDf.collect().head.getLong(0)
-      // approx_count_distinct is not accurate, so we just check the range
-      assert(approxCount > 50 && approxCount < 90)
-    }
   }
 
   override def beforeEach(): Unit = {

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -269,7 +269,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT (
          |  DATE_PART (
-         |    epoch_millisecond ,
+         |    'EPOCH_MILLISECOND' ,
          |    DATE_TRUNC (
          |      'DAY' ,
          |      DATEADD (
@@ -335,7 +335,7 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT (
          |  DATE_PART (
-         |    epoch_millisecond ,
+         |    'EPOCH_MILLISECOND' ,
          |    CONVERT_TIMEZONE (
          |      'America/New_York' ,
          |      'UTC' ,

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -271,19 +271,197 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |  DATE_PART (
          |    epoch_millisecond ,
          |    DATE_TRUNC (
-         |      'day' ,
+         |      'DAY' ,
          |      DATEADD (
-         |        'day' ,
+         |        day ,
          |        CAST ( "SUBQUERY_0"."PD" AS NUMBER ) ,
          |        CONVERT_TIMEZONE (
          |          "SUBQUERY_0"."TZ" ,
-         |          CAST ( "SUBQUERY_0"."TS" AS NUMBER ) ::varchar ) ) ) )
-         |  ) AS "SUBQUERY_1_COL_0" FROM (
+         |          CAST ( CAST ( "SUBQUERY_0"."TS" AS NUMBER ) AS VARCHAR )
+         |        )
+         |      )
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_0" FROM (
          |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
-         |  ) AS "SUBQUERY_0"
-         |""".stripMargin,
+         |) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
       expectedResult
+    )
+  }
+
+  test("AIQ test pushdown string_to_date") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(dt string, fmt string, tz string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"""
+         |('2019-09-01 14:50', 'yyyy-MM-dd HH:mm', 'America/New_York'),
+         |('2019-09-01 02:50 PM', 'yyyy-MM-dd hh:mm a', 'America/New_York'),
+         |('2019-09-01 PM 02:50', 'yyyy-MM-dd a hh:mm', 'America/New_York')
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr("aiq_string_to_date(dt, fmt, tz)")
+    val expectedResult = Seq(
+      Row(1567363800000L),
+      Row(1567363800000L),
+      Row(1567363800000L),
+    )
+    checkAnswer(resultDF, expectedResult)
+
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      "(dt string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      "('2019-09-01 14:50:52')")
+
+    val pushDf = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val pushResultDF = pushDf.selectExpr(
+      "aiq_string_to_date(dt, 'yyyy-MM-dd HH:mm:ss', 'America/New_York')"
+    )
+
+    testPushdown(
+      s"""
+         |SELECT (
+         |  DATE_PART (
+         |    epoch_millisecond ,
+         |    CONVERT_TIMEZONE (
+         |      'America/New_York' ,
+         |      'UTC' ,
+         |      CAST ( TO_TIMESTAMP_NTZ ( "SUBQUERY_0"."DT" , 'yyyy-MM-dd HH24:mi:SS' ) AS VARCHAR )
+         |    )
+         |  )
+         |) AS "SUBQUERY_1_COL_0"
+         |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      pushResultDF,
+      Seq(Row(1567363852000L))
+    )
+  }
+
+  test("AIQ test pushdown date_to_string") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(ts bigint, fmt string, tz string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"""
+         |(1567363852000, 'MM', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd HH:mm', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm a', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd a hh:mm', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd a hh:mm:mm:ss a', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd HH:mm:ss', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'),
+         |(1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr("aiq_date_to_string(ts, fmt, tz)")
+    val expectedResult = Seq(
+      Row("09"),
+      Row("2019-09-01"),
+      Row("2019-09-01 14:50"),
+      Row("2019-09-01 02:50 PM"),
+      Row("2019-09-01 PM 02:50"),
+      Row("2019-09-01 PM 02:50:50:52 PM"),
+      Row("2019-09-01 14:50:52"),
+      Row("2019-09-01 02:50:52"),
+      Row("2019-09-01 02:50:50:52"),
+    )
+    checkAnswer(resultDF, expectedResult)
+
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      "(ts bigint)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      "(1567363852000)")
+
+    val pushDf = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val pushResultDF = pushDf.select(
+      aiq_date_to_string(col("ts"), "MM", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm:mm:ss a", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd M HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMa HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMMMa HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMMM HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd E HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEE HH:mm:ss", "America/New_York"),
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEEEEEE HH:mm:ss", "America/New_York"),
+    )
+    val extraFormattingExpectedResults = Seq(
+      "2019-09-01 09 14:50:52",
+      "2019-09-01 09 14:50:52",
+      "2019-09-01 PM09PM 14:50:52",
+      "2019-09-01 Sep 14:50:52",
+      "2019-09-01 PMSepPM 14:50:52",
+      "2019-09-01 September 14:50:52",
+      "2019-09-01 SeptemberM 14:50:52",
+      "2019-09-01 September 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sun 14:50:52",
+      "2019-09-01 Sunday 14:50:52",
+      "2019-09-01 Sunday 14:50:52",
+    )
+    val pushExpectedResult = Seq(
+      Row(expectedResult.map(_.getString(0)) ++ extraFormattingExpectedResults: _*)
+    )
+    checkAnswer(pushResultDF, pushExpectedResult)
+
+    val finalPushResultDF = pushDf.select(
+      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York")
+    )
+    testPushdown(
+      s"""
+         |SELECT (
+         |  TO_CHAR (
+         |    CONVERT_TIMEZONE (
+         |      'America/New_York' ,
+         |      CAST ( CAST ( "SUBQUERY_0"."TS" AS NUMBER ) AS VARCHAR )
+         |    ),
+         |    'yyyy-MM-dd HH24:mi:SS'
+         |  )
+         |) AS "SUBQUERY_1_COL_0"
+         |FROM (
+         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      finalPushResultDF,
+      Seq(Row("2019-09-01 14:50:52"))
     )
   }
 
@@ -319,20 +497,19 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT (
          |  DATEDIFF (
-         |    'day' ,
-         |    TO_TIMESTAMP (
-         |      CONVERT_TIMEZONE (
-         |        "SUBQUERY_0"."TZ" ,
-         |        CAST ( "SUBQUERY_0"."STARTMS" AS NUMBER ) ::varchar )
+         |    'DAY' ,
+         |    CONVERT_TIMEZONE (
+         |      "SUBQUERY_0"."TZ" ,
+         |      CAST ( CAST ( "SUBQUERY_0"."STARTMS" AS NUMBER ) AS VARCHAR )
          |    ) ,
-         |    TO_TIMESTAMP (
-         |      CONVERT_TIMEZONE (
-         |        "SUBQUERY_0"."TZ" ,
-         |        CAST ( "SUBQUERY_0"."ENDMS" AS NUMBER ) ::varchar ) )
+         |    CONVERT_TIMEZONE (
+         |      "SUBQUERY_0"."TZ" ,
+         |      CAST ( CAST ( "SUBQUERY_0"."ENDMS" AS NUMBER ) AS VARCHAR )
          |    )
-         |  ) AS "SUBQUERY_1_COL_0" FROM (
+         |  )
+         |) AS "SUBQUERY_1_COL_0" FROM (
          |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
-         |  ) AS "SUBQUERY_0"
+         |) AS "SUBQUERY_0"
          |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
       resultDF,
       expectedResult
@@ -375,10 +552,11 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |      (
          |        (
          |          DATEDIFF (
-         |            'day' ,
-         |            TO_TIMESTAMP ( CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , 0 ::varchar ) ) ,
-         |            TO_TIMESTAMP (
-         |              CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , CAST ( "SUBQUERY_0"."ENDMS" AS NUMBER ) ::varchar )
+         |            'DAY' ,
+         |            CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , CAST ( 0 AS VARCHAR ) ) ,
+         |            CONVERT_TIMEZONE (
+         |              "SUBQUERY_0"."TZ" ,
+         |              CAST ( CAST ( "SUBQUERY_0"."ENDMS" AS NUMBER ) AS VARCHAR )
          |            )
          |          ) + 4
          |        ) / 7
@@ -389,11 +567,11 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |      (
          |        (
          |          DATEDIFF (
-         |            'day' ,
-         |            TO_TIMESTAMP ( CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , 0 ::varchar ) ) ,
-         |            TO_TIMESTAMP (
-         |              CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , CAST ( "SUBQUERY_0"."STARTMS" AS NUMBER ) ::varchar )
-         |            )
+         |            'DAY' ,
+         |            CONVERT_TIMEZONE ( "SUBQUERY_0"."TZ" , CAST ( 0 AS VARCHAR ) ) ,
+         |            CONVERT_TIMEZONE (
+         |              "SUBQUERY_0"."TZ" ,
+         |              CAST ( CAST ( "SUBQUERY_0"."STARTMS" AS NUMBER ) AS VARCHAR ) )
          |          ) + 4
          |        ) / 7
          |      )
@@ -430,6 +608,63 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       tmpDF.limit(1).selectExpr(
         "aiq_week_diff(1567363852000, 1567450252000, NULL, tz)"
       ).collect().head == Row(null)
+    )
+  }
+
+  test("AIQ test pushdown day_of_the_week") {
+    jdbcUpdate(s"create or replace table $test_table_date " +
+      s"(ts bigint, tz string)")
+    jdbcUpdate(s"insert into $test_table_date values " +
+      s"""
+         |(1553890107963, 'UTC'),
+         |(1553890107963, 'Asia/Ulan_Bator'),
+         |(1553890107963, 'Pacific/Gambier'),
+         |(1553890107963, NULL),
+         |(NULL, 'UTC')
+         |""".stripMargin.linesIterator.mkString(" ").trim
+    )
+
+    val tmpDF = sparkSession.read
+      .format(SNOWFLAKE_SOURCE_NAME)
+      .options(thisConnectorOptionsNoTable)
+      .option("dbtable", test_table_date)
+      .load()
+
+    val resultDF = tmpDF.selectExpr("aiq_day_of_the_week(ts, tz)")
+    val expectedResult = Seq(
+      Row("friday"),
+      Row("saturday"),
+      Row("friday"),
+      Row(null),
+      Row(null),
+    )
+
+    testPushdown(
+      s"""
+         |SELECT (
+         |  DECODE (
+         |    EXTRACT (
+         |      'DAYOFWEEK_ISO' ,
+         |      CONVERT_TIMEZONE (
+         |        "SUBQUERY_0"."TZ" ,
+         |        CAST ( CAST ( "SUBQUERY_0"."TS" AS NUMBER ) AS VARCHAR )
+         |      )
+         |    ) ,
+         |    1 , 'monday' ,
+         |    2 , 'tuesday' ,
+         |    3 , 'wednesday' ,
+         |    4 , 'thursday' ,
+         |    5 , 'friday' ,
+         |    6 , 'saturday' ,
+         |    7 , 'sunday'
+         |  )
+         |) AS "SUBQUERY_1_COL_0"
+         |FROM (
+         |  SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS"
+         |) AS "SUBQUERY_0"
+         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
+      resultDF,
+      expectedResult
     )
   }
 
@@ -545,177 +780,6 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |""".stripMargin,
       pushDf,
       Seq(Row(1))
-    )
-  }
-
-  test("AIQ test pushdown string_to_date") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
-      s"(dt string, fmt string, tz string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
-      s"""
-         |('2019-09-01 14:50', 'yyyy-MM-dd HH:mm', 'America/New_York'),
-         |('2019-09-01 02:50 PM', 'yyyy-MM-dd hh:mm a', 'America/New_York'),
-         |('2019-09-01 PM 02:50', 'yyyy-MM-dd a hh:mm', 'America/New_York')
-         |""".stripMargin.linesIterator.mkString(" ").trim
-    )
-
-    val tmpDF = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    val resultDF = tmpDF.selectExpr("aiq_string_to_date(dt, fmt, tz)")
-    val expectedResult = Seq(
-      Row(1567363800000L),
-      Row(1567363800000L),
-      Row(1567363800000L),
-    )
-    checkAnswer(resultDF, expectedResult)
-
-    jdbcUpdate(s"create or replace table $test_table_date " +
-      "(dt string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
-      "('2019-09-01 14:50:52')")
-
-    val pushDf = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    val pushResultDF = pushDf.selectExpr(
-      "aiq_string_to_date(dt, 'yyyy-MM-dd HH:mm:ss', 'America/New_York')"
-    )
-
-    testPushdown(
-      s"""
-         |SELECT (
-         |  DATE_PART (
-         |    epoch_millisecond ,
-         |    CONVERT_TIMEZONE (
-         |      'America/New_York' ,
-         |      'UTC' ,
-         |      TO_TIMESTAMP_NTZ ( "SUBQUERY_0"."DT" , 'yyyy-MM-dd HH24:mi:SS' )
-         |    )
-         |  )
-         |) AS "SUBQUERY_1_COL_0"
-         |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
-      pushResultDF,
-      Seq(Row(1567363852000L))
-    )
-  }
-
-  test("AIQ test pushdown date_to_string") {
-    jdbcUpdate(s"create or replace table $test_table_date " +
-      s"(ts bigint, fmt string, tz string)")
-    jdbcUpdate(s"insert into $test_table_date values " +
-      s"""
-         |(1567363852000, 'MM', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd HH:mm', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd hh:mm a', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd a hh:mm', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd a hh:mm:mm:ss a', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd HH:mm:ss', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'),
-         |(1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
-         |""".stripMargin.linesIterator.mkString(" ").trim
-    )
-
-    val tmpDF = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    val resultDF = tmpDF.selectExpr("aiq_date_to_string(ts, fmt, tz)")
-    val expectedResult = Seq(
-      Row("09"),
-      Row("2019-09-01"),
-      Row("2019-09-01 14:50"),
-      Row("2019-09-01 02:50 PM"),
-      Row("2019-09-01 PM 02:50"),
-      Row("2019-09-01 PM 02:50:50:52 PM"),
-      Row("2019-09-01 14:50:52"),
-      Row("2019-09-01 02:50:52"),
-      Row("2019-09-01 02:50:50:52"),
-    )
-    checkAnswer(resultDF, expectedResult)
-
-    jdbcUpdate(s"create or replace table $test_table_date " +
-      "(ts bigint)")
-    jdbcUpdate(s"insert into $test_table_date values " +
-      "(1567363852000)")
-
-    val pushDf = sparkSession.read
-      .format(SNOWFLAKE_SOURCE_NAME)
-      .options(thisConnectorOptionsNoTable)
-      .option("dbtable", test_table_date)
-      .load()
-
-    val pushResultDF = pushDf.select(
-      aiq_date_to_string(col("ts"), "MM", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm a", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd a hh:mm:mm:ss a", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd hh:mm:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd M HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd MM HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMa HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMM HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd aMMMa HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMM HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMM HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd MMMMMM HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd E HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd EE HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEE HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEE HH:mm:ss", "America/New_York"),
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd EEEEEEEE HH:mm:ss", "America/New_York"),
-    )
-    val extraFormattingExpectedResults = Seq(
-      "2019-09-01 09 14:50:52",
-      "2019-09-01 09 14:50:52",
-      "2019-09-01 PM09PM 14:50:52",
-      "2019-09-01 Sep 14:50:52",
-      "2019-09-01 PMSepPM 14:50:52",
-      "2019-09-01 September 14:50:52",
-      "2019-09-01 SeptemberM 14:50:52",
-      "2019-09-01 September 14:50:52",
-      "2019-09-01 Sun 14:50:52",
-      "2019-09-01 Sun 14:50:52",
-      "2019-09-01 Sun 14:50:52",
-      "2019-09-01 Sunday 14:50:52",
-      "2019-09-01 Sunday 14:50:52",
-    )
-    val pushExpectedResult = Seq(
-      Row(expectedResult.map(_.getString(0)) ++ extraFormattingExpectedResults: _*)
-    )
-    checkAnswer(pushResultDF, pushExpectedResult)
-
-    val finalPushResultDF = pushDf.select(
-      aiq_date_to_string(col("ts"), "yyyy-MM-dd HH:mm:ss", "America/New_York")
-    )
-    testPushdown(
-      s"""
-         |SELECT (
-         |  TO_CHAR (
-         |    TO_TIMESTAMP (
-         |      CONVERT_TIMEZONE ( 'America/New_York' , CAST ( "SUBQUERY_0"."TS" AS NUMBER ) ::varchar )
-         |    ) ,
-         |    'yyyy-MM-dd HH24:mi:SS'
-         |  )
-         |) AS "SUBQUERY_1_COL_0"
-         |FROM ( SELECT * FROM ( $test_table_date ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0"
-         |""".stripMargin.linesIterator.map(_.trim).mkString(" ").trim,
-      finalPushResultDF,
-      Seq(Row("2019-09-01 14:50:52"))
     )
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -656,7 +656,8 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
          |    4 , 'thursday' ,
          |    5 , 'friday' ,
          |    6 , 'saturday' ,
-         |    7 , 'sunday'
+         |    7 , 'sunday' ,
+         |    NULL
          |  )
          |) AS "SUBQUERY_1_COL_0"
          |FROM (

--- a/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancement02.scala
@@ -643,20 +643,22 @@ class PushdownEnhancement02 extends IntegrationSuiteBase {
       s"""
          |SELECT (
          |  DECODE (
-         |    EXTRACT (
-         |      'DAYOFWEEK_ISO' ,
-         |      CONVERT_TIMEZONE (
-         |        "SUBQUERY_0"."TZ" ,
-         |        CAST ( CAST ( "SUBQUERY_0"."TS" AS NUMBER ) AS VARCHAR )
-         |      )
-         |    ) ,
-         |    1 , 'monday' ,
-         |    2 , 'tuesday' ,
-         |    3 , 'wednesday' ,
-         |    4 , 'thursday' ,
-         |    5 , 'friday' ,
-         |    6 , 'saturday' ,
-         |    7 , 'sunday' ,
+         |    (
+         |      EXTRACT (
+         |        'DAYOFWEEK_ISO' ,
+         |        CONVERT_TIMEZONE (
+         |          "SUBQUERY_0"."TZ" ,
+         |          CAST ( CAST ( "SUBQUERY_0"."TS" AS NUMBER ) AS VARCHAR )
+         |        )
+         |      ) - 1
+         |    ),
+         |    0 , 'monday' ,
+         |    1 , 'tuesday' ,
+         |    2 , 'wednesday' ,
+         |    3 , 'thursday' ,
+         |    4 , 'friday' ,
+         |    5 , 'saturday' ,
+         |    6 , 'sunday' ,
          |    NULL
          |  )
          |) AS "SUBQUERY_1_COL_0"

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -325,12 +325,9 @@ private[querygeneration] object DateStatement {
       --- ).as[String].collect.head == friday
       SELECT DECODE (
         (
-          EXTRACT (
+          EXTRACT(
             'DAYOFWEEK_ISO' ,
-            CONVERT_TIMEZONE (
-              'UTC' ,
-              CAST ( 1553890107963 AS VARCHAR )
-            )
+            CONVERT_TIMEZONE('UTC', CAST(1553890107963 AS VARCHAR))
           ) - 1
         ) ,
         0 , 'monday' ,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -323,7 +323,7 @@ private[querygeneration] object DateStatement {
       --- spark.sql(
       ---   """select aiq_day_of_the_week(1553890107963, 'UTC')"""
       --- ).as[String].collect.head == friday
-      SELECT DECODE (
+      SELECT DECODE(
         (
           EXTRACT(
             'DAYOFWEEK_ISO' ,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -367,7 +367,7 @@ private[querygeneration] object DateStatement {
 
         // This is a workaround for now since TimestampNTZType is private case class in Spark 3.3
         // Spark 3.4 makes it a public class at which point we can change this logic to use
-        // TimestampType and TimestampNTZType
+        // TimestampType and TimestampNTZType to decide
         val functionName = timezoneStrOpt.map ( _ =>
           "TO_TIMESTAMP"
         ).getOrElse(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -366,6 +366,8 @@ private[querygeneration] object DateStatement {
         if formatStrOpt.forall(_.foldable) =>
 
         // This is a workaround for now since TimestampNTZType is private case class in Spark 3.3
+        // Spark 3.4 makes it a public class at which point we can change this logic to use
+        // TimestampType and TimestampNTZType
         val functionName = timezoneStrOpt.map ( _ =>
           "TO_TIMESTAMP"
         ).getOrElse(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -165,7 +165,7 @@ private[querygeneration] object DateStatement {
           DateAdd(
             ConvertTimezone(CurrentTimeZone(), timezoneStr, timestampLong),
             plusDaysInt,
-          )
+          ),
         )
 
         functionStatement(

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala
@@ -324,12 +324,14 @@ private[querygeneration] object DateStatement {
       ---   """select aiq_day_of_the_week(1553890107963, 'UTC')"""
       --- ).as[String].collect.head == friday
       SELECT DECODE (
-        EXTRACT (
-          'DAYOFWEEK_ISO' ,
-          CONVERT_TIMEZONE (
-            'UTC' ,
-            CAST ( 1553890107963 AS VARCHAR )
-          )
+        (
+          EXTRACT (
+            'DAYOFWEEK_ISO' ,
+            CONVERT_TIMEZONE (
+              'UTC' ,
+              CAST ( 1553890107963 AS VARCHAR )
+            )
+          ) - 1
         ) ,
         0 , 'monday' ,
         1 , 'tuesday' ,

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -149,7 +149,7 @@ private[querygeneration] object MiscStatement {
 
       case Decode(params, replacement) =>
         ConstantString(expr.prettyName.toUpperCase) +
-          blockStatement(convertStatements(fields, params ++ Seq(replacement) : _*))
+          blockStatement(convertStatements(fields, params ++ Seq(replacement): _*))
 
       case _ => null
     })

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -15,6 +15,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   CaseWhen,
   Cast,
   Coalesce,
+  Decode,
   Descending,
   Expression,
   If,
@@ -145,6 +146,10 @@ private[querygeneration] object MiscStatement {
               ", "
             )
           )
+
+      case Decode(params, _) =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatements(fields, params: _*))
 
       case _ => null
     })

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/MiscStatement.scala
@@ -147,9 +147,9 @@ private[querygeneration] object MiscStatement {
             )
           )
 
-      case Decode(params, _) =>
+      case Decode(params, replacement) =>
         ConstantString(expr.prettyName.toUpperCase) +
-          blockStatement(convertStatements(fields, params: _*))
+          blockStatement(convertStatements(fields, params ++ Seq(replacement) : _*))
 
       case _ => null
     })


### PR DESCRIPTION
Adding PushDown Support for `aiq_day_of_the_week`, refactoring Date Functions to use Spark Expressions and removing unnecessary transformations in Snowflake 

## Test Notes
```
-> % sbt compile
...
[success] Total time: 2 s, completed Feb 14, 2024, 11:29:08 AM
```

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement01" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_1.txt
...
[info] - test pushdown IN() function
[info] - test pushdown INSET() function
[info] - test pushdown INSET() function with timestamps and double
[info] - test pushdown COALESCE()
[info] - pushdown EqualNullSafe: operator <=>
[info] Run completed in 1 minute, 15 seconds.
[info] Total number of tests run: 20
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 76 s (01:16), completed Feb 14, 2024, 11:30:47 AM
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.PushdownEnhancement02" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_2.txt
...
[info] - test pushdown number functions: PI() and Round()/Random
[info] - AIQ test pushdown day_start
[info] - AIQ test pushdown string_to_date
[info] - AIQ test pushdown date_to_string
[info] - AIQ test pushdown day_diff
[info] - AIQ test pushdown week_diff
[info] - AIQ test pushdown day_of_the_week
[info] - AIQ test pushdown collect_set
[info] - AIQ test pushdown instr
[info] - AIQ test pushdown md5
[info] - AIQ test pushdown sha1
[info] - AIQ test pushdown sha2
[info] - AIQ test pushdown reverse
[info] - AIQ test pushdown concat_ws
[info] - AIQ test pushdown generate_uuid
[info] - AIQ test pushdown rand
[info] - AIQ test pushdown log
[info] - AIQ test pushdown format_number
[info] - AIQ test approx_count_dist
[info] - test pushdown functions date_add/date_sub
[info] - test pushdown functions date_add/date_sub on Feb last day in leap and non-leap year
[info] - test pushdown WindowExpression: Rank without PARTITION BY
[info] - test pushdown WindowExpression: Rank with PARTITION BY
[info] - test pushdown WindowExpression: DenseRank without PARTITION BY
[info] - test pushdown WindowExpression: DenseRank with PARTITION BY
[info] - literal Date/Timestamp
[info] - test literal null
[info] Run completed in 2 minutes, 25 seconds.
[info] Total number of tests run: 29
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 29, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 147 s (02:27), completed Feb 14, 2024, 11:33:36 AM
```

## Deploy
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters