### PR TITLE
[EXE-2119] Implement Write to Transient Table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq10"
+val sparkConnectorVersion = "2.11.3-aiq11"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -181,7 +181,7 @@ trait IntegrationSuiteBase
   }
 
   // Utility function to test the `kind` of the provided table
-  def testTableKind(testTableName: String, expectedKind: String): Unit = {
+  def testTableKind(testTableName: String, result: String): Unit = {
     val statement = conn.createStatement()
 
     statement.execute("show tables")
@@ -196,7 +196,7 @@ trait IntegrationSuiteBase
       tablesInfo
         .getOrElse(testTableName, None)
         .map(_.toLowerCase)
-        .contains(expectedKind.toLowerCase)
+        .contains(result.toLowerCase)
     )
   }
 

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -180,7 +180,7 @@ trait IntegrationSuiteBase
     }
   }
 
-  // Utility function to test the `kind` of the provided table
+  // Utility function to test the `kind` (permanent | temporary | transient) of the provided table
   def testTableKind(testTableName: String, result: String): Unit = {
     val statement = conn.createStatement()
 

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -189,13 +189,13 @@ trait IntegrationSuiteBase
     val resultSet = statement.getResultSet
     val tablesInfo = mutable.Map.empty[String, Option[String]]
     while (resultSet.next()) {
-      tablesInfo += resultSet.getString(2) -> Option(resultSet.getString(5))
+      tablesInfo +=
+        resultSet.getString(2).toLowerCase -> Option(resultSet.getString(5).toLowerCase)
     }
 
     assert(
       tablesInfo
-        .getOrElse(testTableName, None)
-        .map(_.toLowerCase)
+        .getOrElse(testTableName.toLowerCase, None)
         .contains(result.toLowerCase)
     )
   }

--- a/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/IntegrationSuiteBase.scala
@@ -22,6 +22,7 @@ import net.snowflake.spark.snowflake.pushdowns.SnowflakeStrategy
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
 
+import scala.collection.mutable
 import scala.util.matching.Regex
 
 /**
@@ -179,7 +180,25 @@ trait IntegrationSuiteBase
     }
   }
 
+  // Utility function to test the `kind` of the provided table
+  def testTableKind(testTableName: String, expectedKind: String): Unit = {
+    val statement = conn.createStatement()
 
+    statement.execute("show tables")
+
+    val resultSet = statement.getResultSet
+    val tablesInfo = mutable.Map.empty[String, Option[String]]
+    while (resultSet.next()) {
+      tablesInfo += resultSet.getString(2) -> Option(resultSet.getString(5))
+    }
+
+    assert(
+      tablesInfo
+        .getOrElse(testTableName, None)
+        .map(_.toLowerCase)
+        .contains(expectedKind.toLowerCase)
+    )
+  }
 
   // Utility function to drop some garbage test tables.
   // Be careful to use this function which drops a bunch of tables.

--- a/src/it/scala/net/snowflake/spark/snowflake/JDBCSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/JDBCSuite.scala
@@ -109,10 +109,12 @@ class JDBCSuite extends IntegrationSuiteBase {
     val schema =
       new StructType(Array(StructField("num", IntegerType, nullable = false)))
 
-    val transientParams = params.copy(parameters = params.parameters.map {
-      case ("write_to_transient_table", "false") => "write_to_transient_table" -> "true"
-      case kv => kv
-    })
+    val transientParams = params.copy(
+      parameters = params.parameters.map {
+        case ("write_to_transient_table", "false") => "write_to_transient_table" -> "true"
+        case kv => kv
+      }
+    )
 
     def validate(expectedKind: String): Unit = {
       assert(conn.tableExists(name))

--- a/src/it/scala/net/snowflake/spark/snowflake/JDBCSuite.scala
+++ b/src/it/scala/net/snowflake/spark/snowflake/JDBCSuite.scala
@@ -110,10 +110,7 @@ class JDBCSuite extends IntegrationSuiteBase {
       new StructType(Array(StructField("num", IntegerType, nullable = false)))
 
     val transientParams = params.copy(
-      parameters = params.parameters.map {
-        case ("write_to_transient_table", "false") => "write_to_transient_table" -> "true"
-        case kv => kv
-      }
+      parameters = params.parameters.updated("write_to_transient_table", "true")
     )
 
     def validate(expectedKind: String): Unit = {

--- a/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala
@@ -237,6 +237,11 @@ object Parameters {
     "force_skip_pre_post_action_check_for_session_sharing"
   )
 
+  // adding support for dataframe write to transient table
+  val PARAM_WRITE_TO_TRANSIENT_TABLE: String = knownParam(
+    "write_to_transient_table"
+  )
+
   val DEFAULT_S3_MAX_FILE_SIZE: String = (10 * 1000 * 1000).toString
   val MIN_S3_MAX_FILE_SIZE = 1000000
 
@@ -1033,6 +1038,10 @@ object Parameters {
             s"Only Support azure or s3 storage: $str"
           )
       }
+    }
+
+    def writeToTransientTableCheck: Boolean = {
+      isTrue(parameters.getOrElse(PARAM_WRITE_TO_TRANSIENT_TABLE, "false"))
     }
   }
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -380,7 +380,8 @@ private[snowflake] object DefaultJDBCWrapper extends JDBCWrapper {
                     bindVariableEnabled: Boolean = true): Unit =
       (ConstantString("create") +
         (if (overwrite) "or replace" else "") +
-        (if (temporary) "temporary" else "") + "table" +
+        (if (temporary) "temporary" else "") +
+        (if (!temporary & params.writeToTransientTableCheck) "transient" else "") + "table" +
         (if (!overwrite) "if not exists" else "") + Identifier(name) +
         s"(${schemaString(schema, params)})")
         .execute(bindVariableEnabled)(connection)

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -381,7 +381,7 @@ private[snowflake] object DefaultJDBCWrapper extends JDBCWrapper {
       (ConstantString("create") +
         (if (overwrite) "or replace" else "") +
         (if (temporary) "temporary" else "") +
-        (if (!temporary & params.writeToTransientTableCheck) "transient" else "") + "table" +
+        (if (!temporary && params.writeToTransientTableCheck) "transient" else "") + "table" +
         (if (!overwrite) "if not exists" else "") + Identifier(name) +
         s"(${schemaString(schema, params)})")
         .execute(bindVariableEnabled)(connection)


### PR DESCRIPTION
Adding Support for Write to Transient Table Snowflake

## Test Notes
```
-> % sbt compile
...
[success] Total time: 0 s, completed Feb 15, 2024, 1:35:45 AM
```

```
export SNOWFLAKE_TEST_ACCOUNT="aws"
export SKIP_BIG_DATA_TEST=true
export SPARK_LOCAL_IP=127.0.0.1
export SPARK_CONN_ENV_SFURL=xxxx
export SPARK_CONN_ENV_SFUSER=xxx
export SPARK_CONN_ENV_SFPASSWORD=xxx
export SPARK_CONN_ENV_SFWAREHOUSE=DEMO_WH
export SPARK_CONN_ENV_SFDATABASE=TEST_DB
export SPARK_CONN_ENV_SFSCHEMA=PUBLIC
export SPARK_CONN_ENV_DBTABLE=SPARK_SNOWFLAKE_CI
```

```
sbt "it:testOnly net.snowflake.spark.snowflake.JDBCSuite" >> /Users/yannis.tzemos/Documents/CodeSnips/snow_test_output_jdbcsuite.txt
...
[info] JDBCSuite:
[info] - create and drop table
[info] - create and drop stage
[info] - create and drop pipe
[info] - AIQ create and drop transient table
[info] - test schema
+---+---+
|NUM|STR|
+---+---+
+---+---+

[info] - copy from query
[info] - copy from query using udf
[info] - test union
[info] Run completed in 16 seconds, 255 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 17 s, completed Feb 15, 2024, 1:36:15 AM
```

- Published `"2.11.3-aiq11-yt2"` of the Snowflake Connector
- Picked up the Snowflake Connector version in Flame (locally)

```
~/flame3.3/aiq/maven-clean.sh"
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.407 s
[INFO] Finished at: 2024-02-15T01:38:36-05:00
[INFO] ------------------------------------------------------------------------
```

```
~/flame3.3/aiq/maven-compile.sh
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:50 min
[INFO] Finished at: 2024-02-15T01:48:13-05:00
[INFO] ------------------------------------------------------------------------
```

```
~/flame3.3/aiq/maven-install.sh
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:42 min
[INFO] Finished at: 2024-02-15T02:01:37-05:00
[INFO] ------------------------------------------------------------------------
```

```
~/flame3.3/aiq/spark-shell.sh
...
scala> val df = spark.read.format(snowflakeRelationClass).options(sfOptions).option("dbtable", "dim_customer").load().select(""""customer_id"""")
df: org.apache.spark.sql.DataFrame = ["customer_id": bigint]
```

```
scala> df.alias("df1").join(df.alias("df2"), Seq(""""customer_id""""), "left_outer").select(col("""df1.`"customer_id"`""").alias("customer_id_1"), col("""df2.`"customer_id"`""").alias("customer_id_2")).write.format(snowflakeRelationClass).options(sfOptions).option("dbtable", "yannis_test_table").mode("overwrite").save()
```

<img width="1625" alt="Screenshot 2024-02-15 at 02 34 39" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/db51fad7-4598-4752-8a1e-7bacf90a6537">

<img width="1633" alt="Screenshot 2024-02-15 at 02 38 08" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/7e0a14be-1024-4e07-850f-1444bc211430">

<img width="1303" alt="Screenshot 2024-02-15 at 02 35 02" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/6c839275-c227-4c39-ae62-1f2b5cbec94c">

```
scala> df.alias("df1").join(df.alias("df2"), Seq(""""customer_id""""), "left_outer").select(col("""df1.`"customer_id"`""").alias("customer_id_1"), col("""df2.`"customer_id"`""").alias("customer_id_2")).write.format(snowflakeRelationClass).options(sfOptions).option("dbtable", "yannis_test_table").option("write_to_transient_table", "true").mode("overwrite").save()
```

<img width="1617" alt="Screenshot 2024-02-15 at 02 39 27" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/a18a1709-be66-4042-80c6-6063b3cab9b8">

<img width="1625" alt="Screenshot 2024-02-15 at 02 41 25" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/d722e3cf-a20a-4338-9c18-72edd5759f71">

<img width="1301" alt="Screenshot 2024-02-15 at 02 41 48" src="https://github.com/ActionIQ/spark-snowflake/assets/10472004/422200eb-1f87-492f-9ef6-71c246058cc0">

## Deploy
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters