### PR TITLE
[DP-240][DP-246] Record warehouse read and query latency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import scala.util.Properties
-
-val sparkVersion = "3-3-2-aiq79"
+val sparkVersion = "3-3-2-aiq88"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq12"
+val sparkConnectorVersion = "2.11.3-aiq13"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq88"
+val sparkVersion = "3-3-2-aiq89"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq89"
+val sparkVersion = "3-3-2-aiq88"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -18,7 +18,6 @@
 package net.snowflake.spark.snowflake
 
 import java.io.{PrintWriter, StringWriter}
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -34,6 +33,7 @@ import scala.reflect.ClassTag
 import net.snowflake.client.jdbc.{SnowflakeLoggedFeatureNotSupportedException, SnowflakeResultSet, SnowflakeResultSetSerializable}
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
 
+import java.time.Instant
 import scala.collection.JavaConverters
 
 /** Data Source API implementation for Amazon Snowflake database tables */
@@ -189,7 +189,7 @@ private[snowflake] case class SnowflakeRelation(
       Utils.setLastSelect(statement.toString)
       log.info(s"Now executing below command to read from snowflake:\n${statement.toString}")
 
-      val querySubmissionTime = java.time.Instant.now()
+      val querySubmissionTime = Instant.now()
       val startTime = System.currentTimeMillis()
       val (resultSet, queryID, serializables) = try {
         if (params.isExecuteQueryWithSyncMode) {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -290,7 +290,8 @@ private[snowflake] case class SnowflakeRelation(
         resultSetSerializables,
         params.proxyInfo,
         queryID,
-        params.sfFullURL
+        params.sfFullURL,
+        Some(startTime)
       )
     } finally {
       conn.close()

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -284,14 +284,16 @@ private[snowflake] case class SnowflakeRelation(
       StageReader.sendEgressUsage(conn, queryID, rowCount, dataSize)
       SnowflakeTelemetry.send(conn.getTelemetry)
 
+      val sc = sqlContext.sparkContext
+      sc.setLocalProperty("querySubmissionTime", startTime.toString)
+
       new SnowflakeResultSetRDD[T](
         resultSchema,
-        sqlContext.sparkContext,
+        sc,
         resultSetSerializables,
         params.proxyInfo,
         queryID,
-        params.sfFullURL,
-        Some(startTime)
+        params.sfFullURL
       )
     } finally {
       conn.close()

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -189,9 +189,11 @@ case class ResultIterator[T: ClassTag](
               "query_submitted_at" -> querySubmissionTime.toString,
               "first_row_read_at"-> firstRowReadAt.toString,
               "last_row_read_at" -> lastRowReadAt.toString,
+              "row_count" -> actualReadRowCount.toString,
             )
             context.emitLog(tags)
           case _ =>
+            SnowflakeResultSetRDD.logger.warn("querySubmissionTime not found in TaskContext")
         }
         false
       }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -176,7 +176,7 @@ case class ResultIterator[T: ClassTag](
                |""".stripMargin.filter(_ >= ' '))
         }
         val lastRowReadAt = Instant.now()
-        (Some(context.getLocalProperty("querySubmissionTime")), firstRowReadAt) match {
+        (Option(context.getLocalProperty("querySubmissionTime")), firstRowReadAt) match {
           case (Some(t), Some(firstRowReadAt)) =>
             val formatter = DateTimeFormatter.ISO_INSTANT
             val querySubmissionTime = Instant.from(formatter.parse(t))

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -40,7 +40,6 @@ class SnowflakeResultSetRDD[T: ClassTag](
 
     ResultIterator[T](
       schema,
-//      Some(context.getLocalProperty("querySubmissionTime")),
       context,
       split.asInstanceOf[SnowflakeResultSetPartition].resultSet,
       split.asInstanceOf[SnowflakeResultSetPartition].index,

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -187,7 +187,7 @@ case class ResultIterator[T: ClassTag](
               "warehouse_query_latency_millis" ->
                 s"${Duration.between(querySubmissionTime, firstRowReadAt).toMillis}",
               "data_source" -> "snowflake",
-              "query_submission_time" -> querySubmissionTime.toString,
+              "query_submitted_at" -> querySubmissionTime.toString,
               "first_row_read_at"-> firstRowReadAt.toString,
               "last_row_read_at" -> lastRowReadAt.toString,
             )

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -190,7 +190,7 @@ case class ResultIterator[T: ClassTag](
               "first_row_read_at"-> firstRowReadAt.toString,
               "last_row_read_at" -> lastRowReadAt.toString,
             )
-            SparkContext.emitLog(tags)
+            context.emitLog(tags)
           case _ =>
         }
         false

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -189,7 +189,6 @@ case class ResultIterator[T: ClassTag](
               "query_submitted_at" -> querySubmissionTime.toString,
               "first_row_read_at"-> firstRowReadAt.toString,
               "last_row_read_at" -> lastRowReadAt.toString,
-              "row_count" -> actualReadRowCount.toString,
             )
             context.emitLog(tags)
           case _ =>

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -190,7 +190,6 @@ case class ResultIterator[T: ClassTag](
               s"""Statistics:
                  | warehouse_read_latency=${lastRowReadAt - firstRowReadAt} ms
                  | warehouse_query_latency=${firstRowReadAt - querySubmissionTime} ms
-                 | warehouse_total_time=${lastRowReadAt - querySubmissionTime} ms
                  | data_source=snowflake
                  |""".stripMargin
             )

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -189,6 +189,7 @@ case class ResultIterator[T: ClassTag](
               "query_submitted_at" -> querySubmissionTime.toString,
               "first_row_read_at"-> firstRowReadAt.toString,
               "last_row_read_at" -> lastRowReadAt.toString,
+              "row_count" -> actualReadRowCount.toString,
             )
             context.emitLog(tags)
           case _ =>


### PR DESCRIPTION
DD [link](https://app.datadoghq.com/logs?query=%40trace_id%3Adff91a884042c97f%20%22warehouse_query_latency%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2C%40trace_id&event=AgAAAY8XsWS8Q_ENtQAAAAAAAAAYAAAAAEFZOFhzWDFaQUFCc2FZZnRlTGtzRHdBQQAAACQAAAAAMDE4ZjE3YjEtYTI4Yy00MDkyLTk3ZDAtNzcyOWZiMTE2ODZm&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1688571701531&to_ts=1688658101531&live=true)

![Screenshot 2024-04-26 at 10 33 03 AM](https://github.com/ActionIQ/spark-snowflake/assets/87321568/d2457653-5001-4528-b32f-bc26f9220ce1)
![Screenshot 2024-04-26 at 10 33 08 AM](https://github.com/ActionIQ/spark-snowflake/assets/87321568/3d6c4836-e608-48f2-90eb-7b43338c2b1a)
![Screenshot 2024-04-26 at 10 33 12 AM](https://github.com/ActionIQ/spark-snowflake/assets/87321568/e417f92f-b353-4a73-8077-6e9cf4d21cfc)

Unfortunately, it is not comparable between query history in snowflake for our warehouse_read_latency and warehouse_query_latency. https://docs.snowflake.com/en/sql-reference/account-usage/query_history I wonder if they shorten the `total_elapsed_time` or something like that since the number is lower than what I see in spark also their snowflake connector log 🤷 for example the `query time` is 4 seconds here but shows less than 3s in their db.
![Screenshot 2024-04-26 at 10 34 38 AM](https://github.com/ActionIQ/spark-snowflake/assets/87321568/c65d77c1-dd4c-4491-8d8f-b1c25271ae15)

```
SELECT
Query_text, start_time, end_time, total_elapsed_time, compilation_time, execution_time,
  FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
  where query_tag = 'dff91a884042c97f' and query_type = 'SELECT'
```
![Screenshot 2024-04-26 at 10 30 56 AM](https://github.com/ActionIQ/spark-snowflake/assets/87321568/ad1c9d90-6353-4097-bd70-110598a9e581)

