### PR TITLE
[DP-1][Epic] Hybrid Compute Observability Fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq2092"
+val sparkVersion = "3-3-2-aiq94"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2094"
+val sparkConnectorVersion = "2.11.3-aiq2095-yt1"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq15-yt4"
+val sparkConnectorVersion = "2.11.3-aiq15"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq94"
+val sparkVersion = "3-3-2-aiq2095"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2095-yt2"
+val sparkConnectorVersion = "2.11.3-aiq2095-yt7"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq15-yt2"
+val sparkConnectorVersion = "2.11.3-aiq15-yt3"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2095-yt1"
+val sparkConnectorVersion = "2.11.3-aiq2095-yt2"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq15-yt3"
+val sparkConnectorVersion = "2.11.3-aiq15-yt4"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq15-yt1"
+val sparkConnectorVersion = "2.11.3-aiq15-yt2"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq90"
+val sparkVersion = "3-3-2-aiq2092"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq14"
+val sparkConnectorVersion = "2.11.3-aiq2092"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2092"
+val sparkConnectorVersion = "2.11.3-aiq2093"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2093"
+val sparkConnectorVersion = "2.11.3-aiq2094"
 
 lazy val ItTest = config("it") extend Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-val sparkVersion = "3-3-2-aiq2095"
+val sparkVersion = "3-3-2-aiq95"
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val defaultScalaVersion = "2.12.15"
 
 // increment this version when making a new release
-val sparkConnectorVersion = "2.11.3-aiq2095-yt7"
+val sparkConnectorVersion = "2.11.3-aiq15-yt1"
 
 lazy val ItTest = config("it") extend Test
 

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -170,7 +170,6 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
 
     }
 
-    initializeRelation(sqlContext)
     createRelation(sqlContext, parameters)
   }
 

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -53,7 +53,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
   def this() = this(DefaultJDBCWrapper)
 
   private def initializeRelation(sqlContext: SQLContext): Unit = {
-    val sparkContext = sqlContext.sparkSession.sparkContext
+    val sparkContext = sqlContext.sparkContext
 
     sparkContext.setLocalProperty("dataWarehouse", "snowflake")
 

--- a/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/DefaultSource.scala
@@ -19,7 +19,6 @@ package net.snowflake.spark.snowflake
 
 import net.snowflake.spark.snowflake.streaming.SnowflakeSink
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_SHORT_NAME
-import org.apache.spark.ConnectorTelemetryHelpers
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
@@ -40,9 +39,14 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
     with SchemaRelationProvider
     with CreatableRelationProvider
     with StreamSinkProvider
-    with DataSourceRegister {
+    with DataSourceRegister
+    with DataSourceTelemetryProvider {
 
   override def shortName(): String = SNOWFLAKE_SOURCE_SHORT_NAME
+
+  override def dataSourceType(): String = "spark_connector"
+
+  override def dataWarehouseName(parameters: Map[String, String]): String = shortName()
 
   private val log = LoggerFactory.getLogger(getClass)
 
@@ -67,7 +71,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
     // pass parameters to pushdown functions
     pushdowns.setGlobalParameter(params)
 
-    ConnectorTelemetryHelpers.initializeRelation(sqlContext.sparkContext, "snowflake")
+    initializeRelationTelemetry(sqlContext, parameters)
     SnowflakeRelation(jdbcWrapper, params, None)(sqlContext)
   }
 
@@ -87,7 +91,7 @@ class DefaultSource(jdbcWrapper: JDBCWrapper)
     // pass parameters to pushdown functions
     pushdowns.setGlobalParameter(params)
 
-    ConnectorTelemetryHelpers.initializeRelation(sqlContext.sparkContext, "snowflake")
+    initializeRelationTelemetry(sqlContext, parameters)
     SnowflakeRelation(jdbcWrapper, params, Some(schema))(sqlContext)
   }
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeConnectorUtils.scala
@@ -58,7 +58,7 @@ object SnowflakeConnectorUtils {
     if (!session.experimental.extraStrategies.exists(
           s => s.isInstanceOf[SnowflakeStrategy]
         )) {
-      session.experimental.extraStrategies ++= Seq(new SnowflakeStrategy)
+      session.experimental.extraStrategies ++= Seq(new SnowflakeStrategy(session.sparkContext))
     }
   }
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -674,7 +674,7 @@ private[snowflake] class SnowflakeSQLStatement(
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |"$query"
+                      |<$query>
                       |""".stripMargin
       log.info(logEventNameTagger(logMsg))
     }
@@ -703,7 +703,7 @@ private[snowflake] class SnowflakeSQLStatement(
     val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                        | execute query with bind variable:
                        |""".stripMargin.filter(_ >= ' ')
-    log.info(logEventNameTagger(s"""$logPrefix "$query""""))
+    log.info(logEventNameTagger(s"$logPrefix <$query>"))
 
     val statement = conn.prepareStatement(query)
     varArray.zipWithIndex.foreach {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -665,7 +665,7 @@ private[snowflake] class SnowflakeSQLStatement(
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |<$query>
+                      |'$query'
                       |
                       |callstack =>
                       |${Thread.currentThread.getStackTrace.mkString("\n")}
@@ -674,7 +674,7 @@ private[snowflake] class SnowflakeSQLStatement(
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |<$query>
+                      |'$query'
                       |""".stripMargin
       log.info(logEventNameTagger(logMsg))
     }
@@ -703,7 +703,7 @@ private[snowflake] class SnowflakeSQLStatement(
     val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                        | execute query with bind variable:
                        |""".stripMargin.filter(_ >= ' ')
-    log.info(logEventNameTagger(s"$logPrefix <$query>"))
+    log.info(logEventNameTagger(s"$logPrefix '$query'"))
 
     val statement = conn.prepareStatement(query)
     varArray.zipWithIndex.foreach {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -665,7 +665,7 @@ private[snowflake] class SnowflakeSQLStatement(
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |"$query"
+                      |<$query>
                       |
                       |callstack =>
                       |${Thread.currentThread.getStackTrace.mkString("\n")}

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -27,6 +27,7 @@ import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.client.jdbc.{SnowflakePreparedStatement, SnowflakeResultSet, SnowflakeStatement}
 import net.snowflake.spark.snowflake.io.SnowflakeResultSetRDD
+import org.apache.spark.ConnectorTelemetryHelpers
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
 
@@ -664,18 +665,18 @@ private[snowflake] class SnowflakeSQLStatement(
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |$query
+                      |"$query"
                       |
                       |callstack =>
                       |${Thread.currentThread.getStackTrace.mkString("\n")}
                       |""".stripMargin
-      log.debug(logMsg)
+      log.debug(ConnectorTelemetryHelpers.eventNameLogTagger(logMsg))
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |$query
+                      |"$query"
                       |""".stripMargin
-      log.info(logMsg)
+      log.info(ConnectorTelemetryHelpers.eventNameLogTagger(logMsg))
     }
 
     conn.prepareStatement(query)
@@ -702,7 +703,7 @@ private[snowflake] class SnowflakeSQLStatement(
     val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                        | execute query with bind variable:
                        |""".stripMargin.filter(_ >= ' ')
-    log.info(s"$logPrefix $query")
+    log.info(ConnectorTelemetryHelpers.eventNameLogTagger(s"""$logPrefix "$query""""))
 
     val statement = conn.prepareStatement(query)
     varArray.zipWithIndex.foreach {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -27,7 +27,7 @@ import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.Parameters.MergedParameters
 import net.snowflake.client.jdbc.{SnowflakePreparedStatement, SnowflakeResultSet, SnowflakeStatement}
 import net.snowflake.spark.snowflake.io.SnowflakeResultSetRDD
-import org.apache.spark.ConnectorTelemetryHelpers
+import org.apache.spark.DataSourceTelemetryHelpers
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
 
@@ -590,7 +590,7 @@ private[snowflake] object DefaultJDBCWrapper extends JDBCWrapper {
 private[snowflake] class SnowflakeSQLStatement(
   val numOfVar: Int = 0,
   val list: List[StatementElement] = Nil
-) {
+) extends DataSourceTelemetryHelpers {
 
   private val log = LoggerFactory.getLogger(getClass)
 
@@ -670,13 +670,13 @@ private[snowflake] class SnowflakeSQLStatement(
                       |callstack =>
                       |${Thread.currentThread.getStackTrace.mkString("\n")}
                       |""".stripMargin
-      log.debug(ConnectorTelemetryHelpers.eventNameLogTagger(logMsg))
+      log.debug(logEventNameTagger(logMsg))
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
                       |"$query"
                       |""".stripMargin
-      log.info(ConnectorTelemetryHelpers.eventNameLogTagger(logMsg))
+      log.info(logEventNameTagger(logMsg))
     }
 
     conn.prepareStatement(query)
@@ -703,7 +703,7 @@ private[snowflake] class SnowflakeSQLStatement(
     val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                        | execute query with bind variable:
                        |""".stripMargin.filter(_ >= ' ')
-    log.info(ConnectorTelemetryHelpers.eventNameLogTagger(s"""$logPrefix "$query""""))
+    log.info(logEventNameTagger(s"""$logPrefix "$query""""))
 
     val statement = conn.prepareStatement(query)
     varArray.zipWithIndex.foreach {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
@@ -665,7 +665,7 @@ private[snowflake] class SnowflakeSQLStatement(
     if (log.isDebugEnabled) {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |'$query'
+                      |'${query.trim()}'
                       |
                       |callstack =>
                       |${Thread.currentThread.getStackTrace.mkString("\n")}
@@ -674,7 +674,7 @@ private[snowflake] class SnowflakeSQLStatement(
     } else {
       val logMsg = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                       |execute query without bind variable =>
-                      |'$query'
+                      |'${query.trim()}'
                       |""".stripMargin
       log.info(logEventNameTagger(logMsg))
     }
@@ -703,7 +703,7 @@ private[snowflake] class SnowflakeSQLStatement(
     val logPrefix = s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}:
                        | execute query with bind variable:
                        |""".stripMargin.filter(_ >= ' ')
-    log.info(logEventNameTagger(s"$logPrefix '$query'"))
+    log.info(logEventNameTagger(s"$logPrefix '${query.trim()}'"))
 
     val statement = conn.prepareStatement(query)
     varArray.zipWithIndex.foreach {

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -113,6 +113,11 @@ private[snowflake] case class SnowflakeRelation(
   // when extra pushdowns are disabled.
   override def buildScan(requiredColumns: Array[String],
                          filters: Array[Filter]): RDD[Row] = {
+
+    if (sqlContext.sparkContext.connectorTelemetryPushDownStrategyFailed.get()) {
+      sqlContext.sparkContext.connectorTelemetryNumOfFailedPushDownQueries.getAndIncrement()
+    }
+
     if (requiredColumns.isEmpty) {
       // In the special case where no columns were requested, issue a `count(*)` against Snowflake
       // rather than unloading data.

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -202,7 +202,7 @@ private[snowflake] case class SnowflakeRelation(
       Utils.setLastSelect(statement.toString)
       log.info(
         logEventNameTagger(
-          s"Now executing below command to read from snowflake:\n<${statement.toString}>"
+          s"Now executing below command to read from snowflake:\n'${statement.toString}'"
         )
       )
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -212,12 +212,8 @@ private[snowflake] case class SnowflakeRelation(
         if (params.isExecuteQueryWithSyncMode) {
           val rs = statement.execute(bindVariableEnabled = false)(conn)
           val queryID = rs.asInstanceOf[SnowflakeResultSet].getQueryID
-          log.info(
-            logEventNameTagger(
-              s"The query ID for reading from snowflake is: $queryID; " +
-                s"The query ID URL is:\n${params.getQueryIDUrl(queryID)}"
-            )
-          )
+          log.info(s"The query ID for reading from snowflake is: $queryID; " +
+            s"The query ID URL is:\n${params.getQueryIDUrl(queryID)}")
           val objects = rs
             .asInstanceOf[SnowflakeResultSet]
             .getResultSetSerializables(params.expectedPartitionSize)
@@ -225,12 +221,8 @@ private[snowflake] case class SnowflakeRelation(
         } else {
           val asyncRs = statement.executeAsync(bindVariableEnabled = false)(conn)
           val queryID = asyncRs.asInstanceOf[SnowflakeResultSet].getQueryID
-          log.info(
-            logEventNameTagger(
-              s"The query ID for async reading from snowflake is: $queryID; " +
-                s"The query ID URL is:\n${params.getQueryIDUrl(queryID)}"
-            )
-          )
+          log.info(s"The query ID for async reading from snowflake is: $queryID; " +
+            s"The query ID URL is:\n${params.getQueryIDUrl(queryID)}")
           SparkConnectorContext.addRunningQuery(sqlContext.sparkContext, conn, queryID)
           // The query is executed in async mode, getResultSetSerializables() is blocked
           // until query is done.
@@ -353,12 +345,12 @@ private[snowflake] case class SnowflakeRelation(
       logEventNameTagger(
         // scalastyle:off line.size.limit
         s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}: Total statistics:
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partitionCount=$partitionCount
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.readRowCount=$totalRowCount
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.compressSize=${Utils.getSizeString(totalCompressedSize)}
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.unCompressSize=${Utils.getSizeString(totalUnCompressedSize)}
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.QueryTime=${Utils.getTimeString(queryTimeInMs)}
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.QueryID=$queryID
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partitionCount='$partitionCount'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.readRowCount='$totalRowCount'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.compressSize='${Utils.getSizeString(totalCompressedSize)}'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.unCompressSize='${Utils.getSizeString(totalUnCompressedSize)}'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.QueryTime='${Utils.getTimeString(queryTimeInMs)}'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.QueryID='$queryID'
            |""".stripMargin.linesIterator.mkString(" ")
         // scalastyle:on line.size.limit
       )
@@ -371,9 +363,9 @@ private[snowflake] case class SnowflakeRelation(
       logEventNameTagger(
         // scalastyle:off line.size.limit
         s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}: Average statistics per partition:
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.rowCount=$aveCount
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.compressSize=${Utils.getSizeString(aveCompressSize)}
-           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.unCompressSize=${Utils.getSizeString(aveUnCompressSize)}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.rowCount='$aveCount'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.compressSize='${Utils.getSizeString(aveCompressSize)}'
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.unCompressSize='${Utils.getSizeString(aveUnCompressSize)}'
            |""".stripMargin.linesIterator.mkString(" ")
         // scalastyle:on line.size.limit
       )

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -35,7 +35,6 @@ import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
 import org.apache.spark.ConnectorTelemetryHelpers
 import org.apache.spark.ConnectorTelemetryNamespace.CONNECTOR_TELEMETRY_METRICS_NAMESPACE
 
-import java.time.Instant
 import scala.collection.JavaConverters
 
 /** Data Source API implementation for Amazon Snowflake database tables */

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -32,7 +32,7 @@ import scala.language.postfixOps
 import scala.reflect.ClassTag
 import net.snowflake.client.jdbc.{SnowflakeLoggedFeatureNotSupportedException, SnowflakeResultSet, SnowflakeResultSetSerializable}
 import net.snowflake.spark.snowflake.test.{TestHook, TestHookFlag}
-import org.apache.spark.{DataSourceTelemetry, DataSourceTelemetryHelpers}
+import org.apache.spark.DataSourceTelemetryHelpers
 import org.apache.spark.DataSourceTelemetryNamespace.{DATASOURCE_TELEMETRY_METRICS_NAMESPACE, DATASOURCE_TELEMETRY_READ_ROW_COUNT, DATASOURCE_TELEMETRY_WAREHOUSE_READ_LATENCY_MILLIS}
 
 import scala.collection.JavaConverters

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -340,7 +340,7 @@ private[snowflake] case class SnowflakeRelation(
       }
     }
 
-    if (telemetryMetrics.logStatistics) {
+    if (telemetryMetrics.logStatistics && resultSetSerializables.length > 1) {
       sqlContext.sparkContext.emitMetricsLog(
         telemetryMetrics.compileTelemetryTagsMap() map {
           case (DATASOURCE_TELEMETRY_READ_ROW_COUNT, _) =>

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -202,7 +202,7 @@ private[snowflake] case class SnowflakeRelation(
       Utils.setLastSelect(statement.toString)
       log.info(
         logEventNameTagger(
-          s"Now executing below command to read from snowflake:\n'${statement.toString}'"
+          s"Now executing below command to read from Snowflake:\n'${statement.toString}'"
         )
       )
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -202,7 +202,7 @@ private[snowflake] case class SnowflakeRelation(
       Utils.setLastSelect(statement.toString)
       log.info(
         logEventNameTagger(
-          s"Now executing below command to read from snowflake:\n${statement.toString}"
+          s"Now executing below command to read from snowflake:\n<${statement.toString}>"
         )
       )
 

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -343,9 +343,9 @@ private[snowflake] case class SnowflakeRelation(
     if (telemetryMetrics.logStatistics) {
       sqlContext.sparkContext.emitMetricsLog(
         telemetryMetrics.compileTelemetryTagsMap() map {
-          case (key, _) if key == DATASOURCE_TELEMETRY_READ_ROW_COUNT =>
+          case (DATASOURCE_TELEMETRY_READ_ROW_COUNT, _) =>
             DATASOURCE_TELEMETRY_READ_ROW_COUNT -> totalRowCount.toString
-          case (key, _) if key == DATASOURCE_TELEMETRY_WAREHOUSE_READ_LATENCY_MILLIS =>
+          case (DATASOURCE_TELEMETRY_WAREHOUSE_READ_LATENCY_MILLIS, _) =>
             DATASOURCE_TELEMETRY_WAREHOUSE_READ_LATENCY_MILLIS -> queryTimeInMs.toString
           case t => t
         }

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeRelation.scala
@@ -311,6 +311,10 @@ private[snowflake] case class SnowflakeRelation(
 
       telemetryMetrics.setQueryId(Some(queryID))
 
+      sqlContext.sparkContext.emitMetricsLog(
+        telemetryMetrics.compileGlobalTelemetryTagsMap(Some(statement.toString))
+      )
+
       new SnowflakeResultSetRDD[T](
         resultSchema,
         sqlContext.sparkContext,

--- a/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/SnowflakeTelemetry.scala
@@ -11,11 +11,11 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.Object
 import net.snowflake.client.jdbc.telemetryOOB.{TelemetryEvent, TelemetryService}
 import net.snowflake.spark.snowflake.DefaultJDBCWrapper.DataBaseOperations
 import net.snowflake.spark.snowflake.TelemetryTypes.TelemetryTypes
-import org.apache.spark.ConnectorTelemetryNamespace.CONNECTOR_TELEMETRY_METRICS_NAMESPACE
+import org.apache.spark.DataSourceTelemetryNamespace.DATASOURCE_TELEMETRY_METRICS_NAMESPACE
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.{ConnectorTelemetryHelpers, SparkConf, SparkEnv, TaskContext}
+import org.apache.spark.{DataSourceTelemetryHelpers, SparkConf, SparkEnv, TaskContext}
 
-object SnowflakeTelemetry {
+object SnowflakeTelemetry extends DataSourceTelemetryHelpers {
 
   // type/source/data are first level field names for spark telemetry message.
   // They should not be changed.
@@ -272,11 +272,11 @@ object SnowflakeTelemetry {
                              exception: SnowflakePushdownUnsupportedException)
   : Unit = {
     logger.info(
-      ConnectorTelemetryHelpers.failureLogTagger(
+      logFailureTagger(
         s"""Pushdown fails because of
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.operation=${exception.unsupportedOperation}
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.message=${exception.getMessage}
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.isKnown=${exception.isKnownUnsupportedOperation}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.operation=${exception.unsupportedOperation}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.message=${exception.getMessage}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.isKnown=${exception.isKnownUnsupportedOperation}
            |""".stripMargin.linesIterator.mkString(" ")
       )
     )

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeRDD.scala
@@ -3,8 +3,8 @@ package net.snowflake.spark.snowflake.io
 import java.io.InputStream
 import net.snowflake.spark.snowflake.SparkConnectorContext
 import net.snowflake.spark.snowflake.io.SupportedFormat.SupportedFormat
-import org.apache.spark.ConnectorTelemetryNamespace.CONNECTOR_TELEMETRY_METRICS_NAMESPACE
-import org.apache.spark.{ConnectorTelemetryHelpers, Partition, SparkContext, TaskContext}
+import org.apache.spark.DataSourceTelemetryNamespace.DATASOURCE_TELEMETRY_METRICS_NAMESPACE
+import org.apache.spark.{DataSourceTelemetryHelpers, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 
 class SnowflakeRDD(sc: SparkContext,
@@ -12,7 +12,7 @@ class SnowflakeRDD(sc: SparkContext,
                    format: SupportedFormat,
                    downloadFile: String => InputStream,
                    expectedPartitionCount: Int)
-    extends RDD[String](sc, Nil) {
+    extends RDD[String](sc, Nil) with DataSourceTelemetryHelpers {
 
   @transient private val MIN_FILES_PER_PARTITION = 2
   @transient private val MAX_FILES_PER_PARTITION = 10
@@ -32,11 +32,11 @@ class SnowflakeRDD(sc: SparkContext,
     })
 
     logger.info(
-      ConnectorTelemetryHelpers.eventNameLogTagger(
+      logEventNameTagger(
         // scalastyle:off line.size.limit
         s"""${SnowflakeResultSetRDD.WORKER_LOG_PREFIX}: Start reading
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.partitionId=${snowflakePartition.index}
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.totalFileCount=${snowflakePartition.fileNames.size}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partitionId=${snowflakePartition.index}
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.totalFileCount=${snowflakePartition.fileNames.size}
            |""".stripMargin.linesIterator.mkString(" ")
         // scalastyle:on line.size.limit
       )
@@ -55,12 +55,12 @@ class SnowflakeRDD(sc: SparkContext,
     val fileCount = fileNames.length
     val partitionCount = (fileCount + fileCountPerPartition - 1) / fileCountPerPartition
     logger.info(
-      ConnectorTelemetryHelpers.eventNameLogTagger(
+      logEventNameTagger(
         s"""${SnowflakeResultSetRDD.MASTER_LOG_PREFIX}: Total statistics:
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.fileCount=$fileCount
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.filePerPartition=$fileCountPerPartition
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.actualPartitionCount=$partitionCount
-           |$CONNECTOR_TELEMETRY_METRICS_NAMESPACE.expectedPartitionCount=$expectedPartitionCount
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.fileCount=$fileCount
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.filePerPartition=$fileCountPerPartition
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.actualPartitionCount=$partitionCount
+           |$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.expectedPartitionCount=$expectedPartitionCount
            |""".stripMargin.linesIterator.mkString(" ")
       )
     )

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -134,7 +134,10 @@ case class ResultIterator[T: ClassTag](
 
   TaskContext.get().addTaskCompletionListener[Unit]{ context =>
     if (telemetryMetrics.logStatistics) {
-      context.emitMetricsLog(telemetryMetrics.compileTelemetryTagsMap())
+      context.emitMetricsLog(
+        telemetryMetrics.compileTelemetryTagsMap() ++
+          Map(s"$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partitionId" -> partitionIndex.toString)
+      )
     }
     closeResultSet()
   }

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -136,7 +136,7 @@ case class ResultIterator[T: ClassTag](
     if (telemetryMetrics.logStatistics) {
       context.emitMetricsLog(
         telemetryMetrics.compileTelemetryTagsMap() ++
-          Map(s"$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partitionId" -> partitionIndex.toString)
+          Map(s"$DATASOURCE_TELEMETRY_METRICS_NAMESPACE.partition_id" -> partitionIndex.toString)
       )
     }
     closeResultSet()

--- a/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/io/SnowflakeResultSetRDD.scala
@@ -41,7 +41,6 @@ class SnowflakeResultSetRDD[T: ClassTag](
 
     ResultIterator[T](
       schema,
-      context,
       split.asInstanceOf[SnowflakeResultSetPartition].resultSet,
       split.asInstanceOf[SnowflakeResultSetPartition].index,
       proxyInfo,
@@ -60,7 +59,6 @@ class SnowflakeResultSetRDD[T: ClassTag](
 
 case class ResultIterator[T: ClassTag](
   schema: StructType,
-  context: TaskContext,
   resultSet: SnowflakeResultSetSerializable,
   partitionIndex: Int,
   proxyInfo: Option[ProxyInfo],
@@ -135,7 +133,7 @@ case class ResultIterator[T: ClassTag](
   var currentRowNotConsumedYet: Boolean = false
   var resultSetIsClosed: Boolean = false
 
-  TaskContext.get().addTaskCompletionListener[Unit]{ _ =>
+  TaskContext.get().addTaskCompletionListener[Unit]{ context =>
     if (telemetryMetrics.logStatistics) {
       context.emitMetricsLog(telemetryMetrics.compileTelemetryTagsMap())
     }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
@@ -1,20 +1,22 @@
 package net.snowflake.spark.snowflake.pushdowns
 
-import net.snowflake.spark.snowflake.SnowflakeConnectorFeatureNotSupportException
+import net.snowflake.spark.snowflake.{SnowflakeConnectorFeatureNotSupportException, SnowflakeRelation}
 import net.snowflake.spark.snowflake.pushdowns.querygeneration.QueryBuilder
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
 /** Clean up the plan, then try to generate a query from it for Snowflake.
   * The Try-Catch is unnecessary and may obfuscate underlying problems,
   * but in beta mode we'll do it for safety and let Spark use other strategies
   * in case of unexpected failure.
   */
-class SnowflakeStrategy extends Strategy {
+class SnowflakeStrategy(sparkContext: SparkContext) extends Strategy {
 
   def apply(plan: LogicalPlan): Seq[SparkPlan] = {
     try {
@@ -42,5 +44,13 @@ class SnowflakeStrategy extends Strategy {
     QueryBuilder.getRDDFromPlan(plan).map {
       case (output: Seq[Attribute], rdd: RDD[InternalRow], sql: String) =>
         Seq(SnowflakePlan(output, rdd, sql))
+    }.orElse {
+      // Increase `connectorTelemetryNumOfFailedPushDownQueries` for when QueryBuilder fails
+      // ONLY when Cloud tables are involved in a query plan otherwise it's false signal
+      plan.collectFirst {
+        case LogicalRelation(r, _, _, _) if r.isInstanceOf[SnowflakeRelation] =>
+          sparkContext.connectorTelemetryPushDownStrategyFailed.set(true)
+      }
+      None
     }
 }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
@@ -50,7 +50,7 @@ class SnowflakeStrategy(sparkContext: SparkContext)
         Seq(SnowflakePlan(output, rdd, sql))
     }.orElse {
       // Set `dataSourceTelemetry.pushDownStrategyFailed` to `true` for when QueryBuilder fails
-      // ONLY when Cloud tables are involved in a query plan otherwise it's false signal
+      // ONLY when Snowflake tables are involved in a query plan otherwise it's false signal
       if (foundSnowflakeRelation(plan)) {
         sparkContext.dataSourceTelemetry.pushDownStrategyFailed.set(true)
       }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
@@ -31,7 +31,7 @@ class SnowflakeStrategy(sparkContext: SparkContext)
         log.warn(s"Snowflake doesn't support this feature:\n${ue.getMessage}")
         throw ue
       case e: Exception =>
-        if (foundCloudRelation(plan)) {
+        if (foundSnowflakeRelation(plan)) {
           log.warn(logEventNameTagger(s"PushDown failed:\n${e.getMessage}"))
         }
         Nil
@@ -51,13 +51,13 @@ class SnowflakeStrategy(sparkContext: SparkContext)
     }.orElse {
       // Set `dataSourceTelemetry.pushDownStrategyFailed` to `true` for when QueryBuilder fails
       // ONLY when Cloud tables are involved in a query plan otherwise it's false signal
-      if (foundCloudRelation(plan)) {
+      if (foundSnowflakeRelation(plan)) {
         sparkContext.dataSourceTelemetry.pushDownStrategyFailed.set(true)
       }
       None
     }
 
-  private def foundCloudRelation(plan: LogicalPlan): Boolean = {
+  private def foundSnowflakeRelation(plan: LogicalPlan): Boolean = {
     plan.collectFirst {
       case LogicalRelation(r, _, _, _) if r.isInstanceOf[SnowflakeRelation] => true
     }.getOrElse(false)

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
@@ -45,11 +45,11 @@ class SnowflakeStrategy(sparkContext: SparkContext) extends Strategy {
       case (output: Seq[Attribute], rdd: RDD[InternalRow], sql: String) =>
         Seq(SnowflakePlan(output, rdd, sql))
     }.orElse {
-      // Increase `connectorTelemetryNumOfFailedPushDownQueries` for when QueryBuilder fails
+      // Set `dataSourceTelemetry.pushDownStrategyFailed` to `true` for when QueryBuilder fails
       // ONLY when Cloud tables are involved in a query plan otherwise it's false signal
-      plan.collectFirst {
+      plan match {
         case LogicalRelation(r, _, _, _) if r.isInstanceOf[SnowflakeRelation] =>
-          sparkContext.connectorTelemetryPushDownStrategyFailed.set(true)
+          sparkContext.dataSourceTelemetry.pushDownStrategyFailed.set(true)
       }
       None
     }

--- a/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
@@ -82,7 +82,7 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) {
     try {
       log.debug("Begin query generation.")
       analyzeSparkPlan(plan)
-      generateQueries(plan).get
+      generateQueries(plan).orNull
     } catch {
       // A telemetry message about push-down failure is sent if there are
       // any snowflake tables in the query plan.


### PR DESCRIPTION
- Pick up and setup https://github.com/ActionIQ/flame/pull/595 and https://github.com/ActionIQ/flame/pull/598 for `SnowflakeResultSetRDD`
- Log Tagging for easier debugging

## Test Notes
```
-> % sbt "clean; compile;"
...
[success] Total time: 11 s, completed Jul 11, 2024, 10:04:47 PM
```

- Deployed Dev Cluster to test that changes:

```
2024-07-12T08:39:31.459+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Now executing below command to read from snowflake:
'SELECT ( "SUBQUERY_1"."customer_id" ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE ( "SUBQUERY_0"."customer_id" IS NOT NULL ) ) AS "SUBQUERY_1"'

2024-07-12T08:39:32.089+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Spark Connector Master: Total statistics: hybrid_compute.datasource_telemetry.partitionCount='1' hybrid_compute.datasource_telemetry.readRowCount='17147303' hybrid_compute.datasource_telemetry.compressSize='56.12 MB' hybrid_compute.datasource_telemetry.unCompressSize='65.45 MB' hybrid_compute.datasource_telemetry.QueryTime='629 ms' hybrid_compute.datasource_telemetry.QueryID='01b59d87-040a-7fd8-0000-8ac50159c1aa'

2024-07-12T08:39:32.089+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Spark Connector Master: Average statistics per partition: hybrid_compute.datasource_telemetry.rowCount='17147303' hybrid_compute.datasource_telemetry.compressSize='56.12 MB' hybrid_compute.datasource_telemetry.unCompressSize='65.45 MB'

2024-07-12T08:39:32.096+0000 INFO [SparkLauncherChild-1] SparkContext t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712083917-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql='SELECT ( "SUBQUERY_1"."customer_id" ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE ( "SUBQUERY_0"."customer_id" IS NOT NULL ) ) AS "SUBQUERY_1"' hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d87-040a-7fd8-0000-8ac50159c1aa hybrid_compute.datasource_telemetry.data_warehouse=snowflake

2024-07-12T08:39:36.750+0000 INFO [Executor task launch worker for task 0.0 in stage 0.0 (TID 0)] TaskContextImpl t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=0 - hybrid_compute.datasource_telemetry.application_id=app-20240712083917-0000 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T08:39:17.260Z hybrid_compute.datasource_telemetry.read_column_count=1 hybrid_compute.datasource_telemetry.last_row_read_at=2024-07-12T08:39:36.744Z event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=14936 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=1 hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=2024-07-12T08:39:36.743Z hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=4546 hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d87-040a-7e6f-0000-8ac50159b402 hybrid_compute.datasource_telemetry.data_warehouse=snowflake hybrid_compute.datasource_telemetry.rdd_metrics_source=SnowflakeResultSetRDD hybrid_compute.datasource_telemetry.partition_id=0 hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T08:39:32.196Z hybrid_compute.datasource_telemetry.read_row_count=1

2024-07-12T08:39:39.386+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Spark Connector Master: Total statistics: hybrid_compute.datasource_telemetry.partitionCount='1' hybrid_compute.datasource_telemetry.readRowCount='23899' hybrid_compute.datasource_telemetry.compressSize='126.53 KB' hybrid_compute.datasource_telemetry.unCompressSize='126.53 KB' hybrid_compute.datasource_telemetry.QueryTime='2.39 seconds' hybrid_compute.datasource_telemetry.QueryID='01b59d87-040a-7fd8-0000-8ac50159c1b2'

2024-07-12T08:39:39.388+0000 INFO [SparkLauncherChild-1] SparkContext t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712083917-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql=<SELECT ( "SUBQUERY_12"."SUBQUERY_12_COL_0" ) AS "SUBQUERY_17_COL_0" FROM ( SELECT ( "SUBQUERY_8"."SUBQUERY_8_COL_0" ) AS "SUBQUERY_12_COL_0" FROM ( SELECT ( "SUBQUERY_7"."SUBQUERY_7_COL_0" ) AS "SUBQUERY_8_COL_0" FROM ( SELECT ( "SUBQUERY_6"."SUBQUERY_6_COL_0" ) AS "SUBQUERY_7_COL_0" FROM ( SELECT ( "SUBQUERY_2"."SUBQUERY_2_COL_0" ) AS "SUBQUERY_6_COL_0" , ( "SUBQUERY_5"."SUBQUERY_5_COL_0" ) AS "SUBQUERY_6_COL_1" FROM ( SELECT ( "SUBQUERY_1"."customer_id" ) AS "SUBQUERY_2_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_0" WHERE ( "SUBQUERY_0"."customer_id" IS NOT NULL ) ) AS "SUBQUERY_1" ) AS "SUBQUERY_2" INNER JOIN ( SELECT ( "SUBQUERY_4"."customer_id" ) AS "SUBQUERY_5_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer_demographics_aiq ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_3" WHERE ( ( "SUBQUERY_3"."education_status" IS NOT NULL ) AND ( ( "SUBQUERY_3"."customer_id" IS NOT NULL ) AND ( LOWER ( "SUBQUERY_3"."education_status" ) = '4 yr degree' ) ) ) ) AS "SUBQUERY_4" ) AS "SUBQUERY_5" ON ( "SUBQUERY_2"."SUBQUERY_2_COL_0" = "SUBQUERY_5"."SUBQUERY_5_COL_0" ) ) AS "SUBQUERY_6" ) AS "SUBQUERY_7" GROUP BY "SUBQUERY_7"."SUBQUERY_7_COL_0" ) AS "SUBQUERY_8" WHERE  EXISTS ( SELECT * FROM ( SELECT ( "SUBQUERY_10"."customer_id" ) AS "SUBQUERY_11_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_9" WHERE ( ( "SUBQUERY_9"."optin_status" IS NOT NULL ) AND ( ( "SUBQUERY_9"."customer_id" IS NOT NULL ) AND "SUBQUERY_9"."optin_status" ) ) ) AS "SUBQUERY_10" ) AS "SUBQUERY_11" WHERE ( "SUBQUERY_8"."SUBQUERY_8_COL_0" = "SUBQUERY_11"."SUBQUERY_11_COL_0" ) ) ) AS "SUBQUERY_12" WHERE  EXISTS ( SELECT * FROM ( SELECT ( "SUBQUERY_15"."customer_id" ) AS "SUBQUERY_16_COL_0" FROM ( SELECT * FROM ( SELECT * FROM ( dim_customer ) AS "SF_CONNECTOR_QUERY_ALIAS" ) AS "SUBQUERY_14" WHERE ( ( "SUBQUERY_14"."state" IS NOT NULL ) AND ( ( "SUBQUERY_14"."customer_id" IS NOT NULL ) AND ( LOWER ( "SUBQUERY_14"."state" ) = 'ny' ) ) ) ) AS "SUBQUERY_15" ) AS "SUBQUERY_16" WHERE ( "SUBQUERY_12"."SUBQUERY_12_COL_0" = "SUBQUERY_16"."SUBQUERY_16_COL_0" ) )> hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d87-040a-7fd8-0000-8ac50159c1b2 hybrid_compute.datasource_telemetry.data_warehouse=snowflake

2024-07-12T08:39:57.584+0000 INFO [spark-listener-group-shared] SparkContext t=4d3045343487adce c=80 appFamily=Count crossRunId="customer_id=80|family=Count|segment_id=380587" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_380587_1720773540459_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712083917-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.number_of_queries_submitted_failed_pushdown=0 hybrid_compute.datasource_telemetry.number_of_queries_submitted=16
```

<img width="449" alt="Screenshot 2024-07-12 at 11 41 59" src="https://github.com/user-attachments/assets/e8e3f646-3f64-4e7c-b480-e7ec88bb9c0f">

<img width="264" alt="Screenshot 2024-07-12 at 11 42 39" src="https://github.com/user-attachments/assets/6b54489c-e897-4dd0-b863-8863f3e1701c">

<img width="673" alt="Screenshot 2024-07-12 at 11 43 17" src="https://github.com/user-attachments/assets/7432fe3f-26aa-4557-8e6f-1bef71b2cb64">

<img width="576" alt="Screenshot 2024-07-12 at 11 44 16" src="https://github.com/user-attachments/assets/2fda89c0-1e68-4d99-bca9-81637a617566">

<img width="462" alt="Screenshot 2024-07-12 at 11 45 04" src="https://github.com/user-attachments/assets/492934c6-698f-48a3-ad22-9929852d8803">

<img width="717" alt="Screenshot 2024-07-12 at 11 45 57" src="https://github.com/user-attachments/assets/05c668c0-1855-4ed3-8c90-b9189c7b38ee">

<img width="567" alt="Screenshot 2024-07-12 at 11 47 26" src="https://github.com/user-attachments/assets/f8c8a78a-7029-429b-8eae-bac1fd691eb2">

```
2024-07-12T08:57:48.793+0000 INFO [SparkLauncherChild-1] SnowflakeTelemetry$ t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] [hybrid_compute.datasource_telemetry.failure_log=true] Pushdown fails because of hybrid_compute.datasource_telemetry.operation=scalaudf hybrid_compute.datasource_telemetry.message=pushdown failed hybrid_compute.datasource_telemetry.isKnown=false

2024-07-12T08:57:49.399+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Now executing below command to read from snowflake:
'SELECT "customer_id", "clicked_at" FROM fct_clickstream_aiq WHERE ( "customer_id" IS NOT NULL)'

2024-07-12T08:57:50.288+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Spark Connector Master: Total statistics: hybrid_compute.datasource_telemetry.partitionCount='152' hybrid_compute.datasource_telemetry.readRowCount='678914732' hybrid_compute.datasource_telemetry.compressSize='4.81 GB' hybrid_compute.datasource_telemetry.unCompressSize='12.65 GB' hybrid_compute.datasource_telemetry.QueryTime='888 ms' hybrid_compute.datasource_telemetry.QueryID='01b59d99-040a-7fd8-0000-8ac50159c31e'

2024-07-12T08:57:50.288+0000 INFO [SparkLauncherChild-1] SnowflakeRelation t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Spark Connector Master: Average statistics per partition: hybrid_compute.datasource_telemetry.rowCount='4466544' hybrid_compute.datasource_telemetry.compressSize='32.41 MB' hybrid_compute.datasource_telemetry.unCompressSize='85.21 MB'

2024-07-12T08:57:50.289+0000 INFO [SparkLauncherChild-1] SparkContext t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712085741-0001 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql='SELECT "customer_id", "clicked_at" FROM fct_clickstream_aiq WHERE ( "customer_id" IS NOT NULL)' hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d99-040a-7fd8-0000-8ac50159c31e hybrid_compute.datasource_telemetry.data_warehouse=snowflake

2024-07-12T08:58:02.500+0000 INFO [Executor task launch worker for task 0.0 in stage 0.0 (TID 0)] TaskContextImpl t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=0 - hybrid_compute.datasource_telemetry.application_id=app-20240712085741-0001 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T08:57:41.045Z hybrid_compute.datasource_telemetry.read_column_count=2 hybrid_compute.datasource_telemetry.last_row_read_at=2024-07-12T08:58:01.180Z event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=9837 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=6645 hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=2024-07-12T08:57:54.534Z hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=3652 hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d99-040a-7fd8-0000-8ac50159c32a hybrid_compute.datasource_telemetry.data_warehouse=snowflake hybrid_compute.datasource_telemetry.rdd_metrics_source=SnowflakeResultSetRDD hybrid_compute.datasource_telemetry.partition_id=0 hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T08:57:50.882Z hybrid_compute.datasource_telemetry.read_row_count=3653632

2024-07-12T08:58:04.353+0000 INFO [Executor task launch worker for task 7.0 in stage 0.0 (TID 7)] TaskContextImpl t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=0 - hybrid_compute.datasource_telemetry.application_id=app-20240712085741-0001 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T08:57:41.045Z hybrid_compute.datasource_telemetry.read_column_count=2 hybrid_compute.datasource_telemetry.last_row_read_at=2024-07-12T08:58:02.629Z event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=9837 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=7621 hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=2024-07-12T08:57:55.007Z hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=4125 hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=01b59d99-040a-7fd8-0000-8ac50159c32a hybrid_compute.datasource_telemetry.data_warehouse=snowflake hybrid_compute.datasource_telemetry.rdd_metrics_source=SnowflakeResultSetRDD hybrid_compute.datasource_telemetry.partition_id=7 hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T08:57:50.882Z hybrid_compute.datasource_telemetry.read_row_count=4472832

2024-07-12T08:59:39.150+0000 INFO [spark-listener-group-shared] SparkContext t=b86e2791d3dafa82 c=80 appFamily=Count crossRunId="customer_id=80|family=Count|variable_id=88380" appName=yannis-testing-hc-all_cx_hub_benchmark_80_Count_88380_1720774649108_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712085741-0001 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.number_of_queries_submitted_failed_pushdown=2 hybrid_compute.datasource_telemetry.number_of_queries_submitted=4
```

<img width="253" alt="Screenshot 2024-07-12 at 12 02 10" src="https://github.com/user-attachments/assets/5dd508ce-23bc-422c-9d53-4b319b5e8496">

<img width="444" alt="Screenshot 2024-07-12 at 12 03 26" src="https://github.com/user-attachments/assets/1dc34204-ede2-4a45-bb5e-b3906d1f7603">

<img width="247" alt="Screenshot 2024-07-12 at 12 03 52" src="https://github.com/user-attachments/assets/bddbac1c-5a69-4bf5-9ace-6bfc3bbedbfc">

<img width="672" alt="Screenshot 2024-07-12 at 12 04 20" src="https://github.com/user-attachments/assets/5d1b689b-112a-4944-ad25-e3a6dcbc2306">

<img width="580" alt="Screenshot 2024-07-12 at 12 05 17" src="https://github.com/user-attachments/assets/acf717a6-58b1-485d-a555-3fc3aa862c08">

<img width="561" alt="Screenshot 2024-07-12 at 12 05 59" src="https://github.com/user-attachments/assets/ad2455d5-747a-4908-ab07-29987b3e1db5">

<img width="550" alt="Screenshot 2024-07-12 at 12 06 51" src="https://github.com/user-attachments/assets/520fd0c3-6518-45c3-a8e7-d18178bfdf15">

## Deploy Notes
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters